### PR TITLE
feat: Implement conversation persistence for Q&A interactions

### DIFF
--- a/backend/src/backend.Application/Services/RagService/DTO/AskQuestionRequest.cs
+++ b/backend/src/backend.Application/Services/RagService/DTO/AskQuestionRequest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace backend.Services.RagService.DTO;
@@ -15,4 +16,11 @@ public class AskQuestionRequest
     [Required]
     [MaxLength(30_000)]
     public string QuestionText { get; set; }
+
+    /// <summary>
+    /// Optional ID of an existing conversation to continue.
+    /// When null, the service creates a new conversation for the question.
+    /// When provided, the service reuses it only if it belongs to the current user.
+    /// </summary>
+    public Guid? ConversationId { get; set; }
 }

--- a/backend/src/backend.Application/Services/RagService/DTO/RagAnswerResult.cs
+++ b/backend/src/backend.Application/Services/RagService/DTO/RagAnswerResult.cs
@@ -43,6 +43,12 @@ public class RagAnswerResult
     public Guid? AnswerId { get; set; }
 
     /// <summary>
+    /// ID of the persisted <see cref="backend.Domains.QA.Conversation"/> linked to this exchange.
+    /// <c>null</c> when no conversation was persisted or surfaced to the client.
+    /// </summary>
+    public Guid? ConversationId { get; set; }
+
+    /// <summary>
     /// ISO 639-1 code of the detected input language (e.g. "zu", "st", "af", "en").
     /// Defaults to "en" when language detection is unavailable.
     /// </summary>

--- a/backend/src/backend.Application/Services/RagService/IRagAppService.cs
+++ b/backend/src/backend.Application/Services/RagService/IRagAppService.cs
@@ -21,8 +21,11 @@ public interface IRagAppService : IApplicationService
     /// on how strongly the indexed legislation supports the question, whether official guidance
     /// supplements the law, and whether urgent risk indicators require a safer posture.
     /// </summary>
-    /// <param name="request">The user's question. <see cref="AskQuestionRequest.QuestionText"/> must not be null or whitespace.</param>
-    /// <returns>A <see cref="RagAnswerResult"/> with the answer text, citations, and chunk IDs.</returns>
+    /// <param name="request">
+    /// The user's question. <see cref="AskQuestionRequest.QuestionText"/> must not be null or whitespace.
+    /// <see cref="AskQuestionRequest.ConversationId"/> may be supplied to continue an existing conversation owned by the current user.
+    /// </param>
+    /// <returns>A <see cref="RagAnswerResult"/> with the answer text, citations, and persistence identifiers.</returns>
     Task<RagAnswerResult> AskAsync(AskQuestionRequest request);
 
     /// <summary>

--- a/backend/src/backend.Application/Services/RagService/RagAppService.cs
+++ b/backend/src/backend.Application/Services/RagService/RagAppService.cs
@@ -135,12 +135,12 @@ public class RagAppService : ApplicationService, IRagAppService
         var userId = AbpSession.UserId
             ?? throw new Abp.Authorization.AbpAuthorizationException("You must be signed in to view conversation history.");
 
-        var conversations = await _conversationRepository
-            .GetAll()
-            .Include(c => c.Questions)
-            .Where(c => c.UserId == userId)
-            .OrderByDescending(c => c.StartedAt)
-            .ToListAsync();
+        var conversations = await ListConversationsAsync(
+            _conversationRepository
+                .GetAll()
+                .Include(c => c.Questions)
+                .Where(c => c.UserId == userId)
+                .OrderByDescending(c => c.StartedAt));
 
         var items = conversations.Select(conversation => new ConversationSummaryDto
         {
@@ -197,6 +197,7 @@ public class RagAppService : ApplicationService, IRagAppService
         {
             await PersistQuestionIfAuthenticatedAsync(
                 userId,
+                request.ConversationId,
                 request.QuestionText,
                 translatedText,
                 detectedLanguage);
@@ -219,6 +220,7 @@ public class RagAppService : ApplicationService, IRagAppService
 
             await PersistQuestionIfAuthenticatedAsync(
                 userId,
+                request.ConversationId,
                 request.QuestionText,
                 translatedText,
                 detectedLanguage);
@@ -238,18 +240,21 @@ public class RagAppService : ApplicationService, IRagAppService
             retrievalDecision);
 
         Guid? answerId = null;
+        Guid? conversationId = null;
         if (userId.HasValue)
         {
-            var questionId = await PersistQuestionAsync(
+            var persistedQuestion = await PersistQuestionAsync(
                 userId.Value,
+                request.ConversationId,
                 request.QuestionText,
                 translatedText,
                 detectedLanguage);
+            conversationId = persistedQuestion.ConversationId;
 
             if (ShouldPersistAnswer(retrievalDecision.AnswerMode))
             {
                 answerId = await PersistAnswerAsync(
-                    questionId,
+                    persistedQuestion.QuestionId,
                     answerText,
                     detectedLanguage,
                     retrievalDecision.SelectedChunks);
@@ -263,6 +268,7 @@ public class RagAppService : ApplicationService, IRagAppService
             Citations = CreateCitations(retrievalDecision.SelectedChunks),
             ChunkIds = retrievalDecision.SelectedChunks.Select(chunk => chunk.ChunkId).ToList(),
             AnswerId = answerId,
+            ConversationId = conversationId,
             DetectedLanguageCode = detectedLanguageCode,
             AnswerMode = retrievalDecision.AnswerMode,
             ConfidenceBand = retrievalDecision.ConfidenceBand,
@@ -275,6 +281,7 @@ public class RagAppService : ApplicationService, IRagAppService
 
     private async Task PersistQuestionIfAuthenticatedAsync(
         long? userId,
+        Guid? conversationId,
         string originalText,
         string translatedText,
         Language language)
@@ -284,7 +291,7 @@ public class RagAppService : ApplicationService, IRagAppService
             return;
         }
 
-        await PersistQuestionAsync(userId.Value, originalText, translatedText, language);
+        await PersistQuestionAsync(userId.Value, conversationId, originalText, translatedText, language);
     }
 
     private async Task EnsureIndexLoadedAsync()
@@ -410,31 +417,38 @@ public class RagAppService : ApplicationService, IRagAppService
                ?? throw new InvalidOperationException("OpenAI chat response contained no content.");
     }
 
-    protected virtual async Task<Guid> PersistQuestionAsync(
+    protected virtual async Task<PersistedQuestionResult> PersistQuestionAsync(
         long userId,
+        Guid? conversationId,
         string originalText,
         string translatedText,
         Language language)
     {
-        var conversation = new Conversation
+        var resolvedConversationId = conversationId.HasValue
+            ? (await _conversationRepository.FirstOrDefaultAsync(
+                conversation => conversation.Id == conversationId.Value && conversation.UserId == userId))?.Id
+            : null;
+
+        if (!resolvedConversationId.HasValue)
         {
-            UserId = userId,
-            Language = language,
-            InputMethod = InputMethod.Text,
-            StartedAt = DateTime.UtcNow,
-            IsPublicFaq = false
-        };
-        var conversationId = await _conversationRepository.InsertAndGetIdAsync(conversation);
+            resolvedConversationId = await CreateConversationAsync(userId, language);
+        }
 
         var question = new Question
         {
-            ConversationId = conversationId,
+            ConversationId = resolvedConversationId.Value,
             OriginalText = originalText,
             TranslatedText = translatedText,
             Language = language,
-            InputMethod = InputMethod.Text
+            InputMethod = InputMethod.Text,
         };
-        return await _questionRepository.InsertAndGetIdAsync(question);
+        var questionId = await _questionRepository.InsertAndGetIdAsync(question);
+        return new PersistedQuestionResult(questionId, resolvedConversationId.Value);
+    }
+
+    protected virtual Task<List<Conversation>> ListConversationsAsync(IOrderedQueryable<Conversation> query)
+    {
+        return query.ToListAsync();
     }
 
     protected virtual async Task<Guid> PersistAnswerAsync(
@@ -464,6 +478,20 @@ public class RagAppService : ApplicationService, IRagAppService
         }
 
         return answerId;
+    }
+
+    private async Task<Guid> CreateConversationAsync(long userId, Language language)
+    {
+        var conversation = new Conversation
+        {
+            UserId = userId,
+            Language = language,
+            InputMethod = InputMethod.Text,
+            StartedAt = DateTime.UtcNow,
+            IsPublicFaq = false
+        };
+
+        return await _conversationRepository.InsertAndGetIdAsync(conversation);
     }
 
     private static string SanitizeClarificationQuestion(string generatedQuestion, string fallbackQuestion)
@@ -530,4 +558,6 @@ public class RagAppService : ApplicationService, IRagAppService
 
     private sealed record OpenAiChatChoice(
         [property: JsonPropertyName("message")] OpenAiChatMessage Message);
+
+    protected sealed record PersistedQuestionResult(Guid QuestionId, Guid ConversationId);
 }

--- a/backend/src/backend.Web.Host/App_Data/Logs/Logs.txt
+++ b/backend/src/backend.Web.Host/App_Data/Logs/Logs.txt
@@ -6787,3 +6787,1821 @@ INFO  2026-04-02 11:43:57,813 [16   ] .Mvc.Infrastructure.ObjectResultExecutor -
 INFO  2026-04-02 11:43:57,818 [16   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.ContractController.Get (backend.Web.Host) in 2261.1317ms
 INFO  2026-04-02 11:43:57,819 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.ContractController.Get (backend.Web.Host)'
 INFO  2026-04-02 11:43:57,820 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/contract/019d4d7e-294f-7c29-9887-a4619acd4b28 - 200 - application/json;+charset=utf-8 2282.0782ms
+DEBUG 2026-04-02 12:34:19,059 [10   ] Abp.Modules.AbpModuleManager             - Shutting down has been started
+DEBUG 2026-04-02 12:34:19,070 [10   ] Abp.BackgroundJobs.BackgroundJobManager  - Stop background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 12:34:19,071 [10   ] , Culture=neutral, PublicKeyToken=null]] - Stop background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 12:34:19,072 [10   ] Abp.BackgroundJobs.BackgroundJobManager  - WaitToStop background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 12:34:19,072 [10   ] , Culture=neutral, PublicKeyToken=null]] - WaitToStop background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 12:34:19,072 [10   ] Abp.Modules.AbpModuleManager             - Shutting down completed.
+INFO  2026-04-02 12:34:19,075 [10   ] Microsoft.Hosting.Lifetime               - Application is shutting down...
+DEBUG 2026-04-02 12:39:45,678 [2    ] Abp.Modules.AbpModuleManager             - Loading Abp modules...
+DEBUG 2026-04-02 12:39:45,689 [2    ] Abp.Modules.AbpModuleManager             - Found 15 ABP modules in total.
+DEBUG 2026-04-02 12:39:45,701 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.Web.Host.Startup.backendWebHostModule, backend.Web.Host, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,702 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendWebCoreModule, backend.Web.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,703 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendApplicationModule, backend.Application, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,703 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendCoreModule, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,703 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.AbpZeroCoreModule, Abp.ZeroCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,703 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.AbpZeroCommonModule, Abp.Zero.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,703 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AbpKernelModule, Abp, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,704 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AutoMapper.AbpAutoMapperModule, Abp.AutoMapper, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,704 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.EntityFrameworkCore.backendEntityFrameworkModule, backend.EntityFrameworkCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,704 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.EntityFrameworkCore.AbpZeroCoreEntityFrameworkCoreModule, Abp.ZeroCore.EntityFrameworkCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,705 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.EntityFrameworkCore.AbpEntityFrameworkCoreModule, Abp.EntityFrameworkCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,705 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.EntityFramework.AbpEntityFrameworkCommonModule, Abp.EntityFramework.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,705 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AspNetCore.AbpAspNetCoreModule, Abp.AspNetCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,705 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Web.AbpWebCommonModule, Abp.Web.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,705 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AspNetCore.SignalR.AbpAspNetCoreSignalRModule, Abp.AspNetCore.SignalR, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:45,706 [2    ] Abp.Modules.AbpModuleManager             - 15 modules loaded.
+DEBUG 2026-04-02 12:39:45,799 [2    ] o.Configuration.LanguageManagementConfig - Converted Abp (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 12:39:45,799 [2    ] o.Configuration.LanguageManagementConfig - Converted AbpZero (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 12:39:45,799 [2    ] o.Configuration.LanguageManagementConfig - Converted backend (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 12:39:45,799 [2    ] o.Configuration.LanguageManagementConfig - Converted AbpWeb (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 12:39:46,029 [2    ] ameworkCore.AbpEntityFrameworkCoreModule - Registering DbContext: backend.EntityFrameworkCore.backendDbContext, backend.EntityFrameworkCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 12:39:46,198 [2    ] Abp.Localization.LocalizationManager     - Initializing 4 localization sources.
+DEBUG 2026-04-02 12:39:46,228 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: Abp
+DEBUG 2026-04-02 12:39:46,237 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: AbpZero
+DEBUG 2026-04-02 12:39:46,243 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: backend
+DEBUG 2026-04-02 12:39:46,246 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: AbpWeb
+DEBUG 2026-04-02 12:39:46,252 [2    ] Abp.BackgroundJobs.BackgroundJobManager  - Start background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 12:39:46,255 [2    ] , Culture=neutral, PublicKeyToken=null]] - Start background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 12:39:46,269 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - Found 10 classes define auto mapping attributes
+DEBUG 2026-04-02 12:39:46,269 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Users.Dto.CreateUserDto
+DEBUG 2026-04-02 12:39:46,271 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Users.Dto.UserDto
+DEBUG 2026-04-02 12:39:46,271 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Sessions.Dto.TenantLoginInfoDto
+DEBUG 2026-04-02 12:39:46,271 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Sessions.Dto.UserLoginInfoDto
+DEBUG 2026-04-02 12:39:46,271 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.LegalDocumentService.DTO.LegalDocumentDto
+DEBUG 2026-04-02 12:39:46,272 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.LegalDocumentService.DTO.LegalDocumentListDto
+DEBUG 2026-04-02 12:39:46,272 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.CategoryService.DTO.CategoryDto
+DEBUG 2026-04-02 12:39:46,272 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Roles.Dto.PermissionDto
+DEBUG 2026-04-02 12:39:46,272 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.MultiTenancy.Dto.CreateTenantDto
+DEBUG 2026-04-02 12:39:46,272 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.MultiTenancy.Dto.TenantDto
+INFO  2026-04-02 12:40:06,133 [2    ] tCore.Builder.RequestLocalizationOptions - Supported Request Localization Cultures: en,es-MX,fr,de,it,nl,pt-BR,tr,ru,ar,fa,ja,zh-Hans
+INFO  2026-04-02 12:40:06,443 [2    ] Microsoft.Hosting.Lifetime               - Now listening on: https://localhost:44311
+INFO  2026-04-02 12:40:06,443 [2    ] Microsoft.Hosting.Lifetime               - Now listening on: http://localhost:21021
+INFO  2026-04-02 12:40:06,503 [2    ] Microsoft.Hosting.Lifetime               - Application started. Press Ctrl+C to shut down.
+INFO  2026-04-02 12:40:06,504 [2    ] Microsoft.Hosting.Lifetime               - Hosting environment: Development
+INFO  2026-04-02 12:40:06,504 [2    ] Microsoft.Hosting.Lifetime               - Content root path: C:\Users\Nhlakanipho\Documents\Projects\Mzansi-legal\backend\src\backend.Web.Host
+INFO  2026-04-02 12:40:07,256 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/ - - -
+INFO  2026-04-02 12:40:07,550 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host)'
+INFO  2026-04-02 12:40:07,591 [8    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "Index", controller = "Home", area = ""}. Executing controller action with signature Microsoft.AspNetCore.Mvc.IActionResult Index() on controller backend.Web.Host.Controllers.HomeController (backend.Web.Host).
+INFO  2026-04-02 12:40:09,367 [8    ] vc.Infrastructure.RedirectResultExecutor - Executing RedirectResult, redirecting to /swagger.
+INFO  2026-04-02 12:40:09,389 [8    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host) in 1777.3726ms
+INFO  2026-04-02 12:40:09,390 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host)'
+INFO  2026-04-02 12:40:09,403 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/ - 302 - - 2147.8955ms
+INFO  2026-04-02 12:40:09,500 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/_framework/aspnetcore-browser-refresh.js - - -
+INFO  2026-04-02 12:40:09,502 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/_vs/browserLink - - -
+INFO  2026-04-02 12:40:09,512 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/_framework/aspnetcore-browser-refresh.js - 200 14937 application/javascript;+charset=utf-8 11.6738ms
+INFO  2026-04-02 12:40:09,543 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/_vs/browserLink - 200 - text/javascript;+charset=UTF-8 40.6112ms
+INFO  2026-04-02 12:40:09,579 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/AntiForgery/SetCookie - - -
+INFO  2026-04-02 12:40:09,600 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/swagger/v1/swagger.json - - -
+INFO  2026-04-02 12:40:10,435 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host)'
+INFO  2026-04-02 12:40:10,442 [15   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "SetCookie", controller = "AntiForgery", area = ""}. Executing controller action with signature Void SetCookie() on controller backend.Web.Host.Controllers.AntiForgeryController (backend.Web.Host).
+INFO  2026-04-02 12:40:10,514 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/swagger/v1/swagger.json - 200 - application/json;charset=utf-8 913.9967ms
+INFO  2026-04-02 12:40:11,861 [15   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 12:40:11,875 [15   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host) in 1433.5857ms
+INFO  2026-04-02 12:40:11,876 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host)'
+INFO  2026-04-02 12:40:11,876 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/AntiForgery/SetCookie - 200 - application/json;+charset=utf-8 2296.8139ms
+INFO  2026-04-02 12:40:34,065 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 12:40:34,072 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 12:40:34,080 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 13.2568ms
+INFO  2026-04-02 12:40:34,083 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 12:40:34,089 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 12:40:35,208 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 12:40:35,260 [8    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+WARN  2026-04-02 12:40:35,533 [8    ] Microsoft.EntityFrameworkCore.Query      - Compiling a query which loads related collections for more than one collection navigation, either via 'Include' or through projection, but no 'QuerySplittingBehavior' has been configured. By default, Entity Framework will use 'QuerySplittingBehavior.SingleQuery', which can potentially result in slow query performance. See https://go.microsoft.com/fwlink/?linkid=2134277 for more information. To identify the query that's triggering this warning call 'ConfigureWarnings(w => w.Throw(RelationalEventId.MultipleCollectionIncludeWarning))'.
+INFO  2026-04-02 12:40:35,857 [16   ] ckend.Web.Host.Startup.RagStartupService - [RagService] Chunk embeddings loaded into memory. RAG service is ready.
+INFO  2026-04-02 12:40:37,720 [8    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 12:40:37,763 [8    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2502.5648ms
+INFO  2026-04-02 12:40:37,763 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 12:40:37,764 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 3680.6903ms
+INFO  2026-04-02 12:57:54,933 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 12:57:54,942 [21   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 12:57:54,955 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 21.6982ms
+INFO  2026-04-02 12:57:54,958 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 12:57:54,960 [21   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 12:57:54,997 [21   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 12:57:55,019 [21   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 12:57:57,160 [21   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 12:57:57,176 [21   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2155.809ms
+INFO  2026-04-02 12:57:57,176 [21   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 12:57:57,177 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2218.6494ms
+INFO  2026-04-02 12:59:18,506 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 12:59:18,507 [21   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 12:59:18,507 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 0.8069ms
+INFO  2026-04-02 12:59:18,510 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 12:59:18,510 [21   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 12:59:18,512 [21   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 12:59:18,516 [21   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 12:59:23,279 [21   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 12:59:23,279 [21   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 4762.3063ms
+INFO  2026-04-02 12:59:23,279 [21   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 12:59:23,280 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 4769.7985ms
+INFO  2026-04-02 13:04:52,507 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:04:52,507 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:04:52,508 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 0.5681ms
+INFO  2026-04-02 13:04:52,510 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:04:52,511 [21   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:04:52,548 [21   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:04:52,590 [21   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:04:54,668 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:04:54,668 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2078.2725ms
+INFO  2026-04-02 13:04:54,668 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:04:54,669 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2158.2552ms
+DEBUG 2026-04-02 13:04:56,682 [18   ] Abp.Modules.AbpModuleManager             - Shutting down has been started
+DEBUG 2026-04-02 13:04:56,686 [18   ] Abp.BackgroundJobs.BackgroundJobManager  - Stop background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 13:04:56,686 [18   ] , Culture=neutral, PublicKeyToken=null]] - Stop background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 13:04:57,172 [18   ] Abp.BackgroundJobs.BackgroundJobManager  - WaitToStop background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 13:04:57,174 [18   ] , Culture=neutral, PublicKeyToken=null]] - WaitToStop background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 13:04:57,174 [18   ] Abp.Modules.AbpModuleManager             - Shutting down completed.
+INFO  2026-04-02 13:04:57,175 [18   ] Microsoft.Hosting.Lifetime               - Application is shutting down...
+DEBUG 2026-04-02 13:05:18,338 [2    ] Abp.Modules.AbpModuleManager             - Loading Abp modules...
+DEBUG 2026-04-02 13:05:18,359 [2    ] Abp.Modules.AbpModuleManager             - Found 15 ABP modules in total.
+DEBUG 2026-04-02 13:05:18,396 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.Web.Host.Startup.backendWebHostModule, backend.Web.Host, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,399 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendWebCoreModule, backend.Web.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,401 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendApplicationModule, backend.Application, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,402 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendCoreModule, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,402 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.AbpZeroCoreModule, Abp.ZeroCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,403 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.AbpZeroCommonModule, Abp.Zero.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,403 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AbpKernelModule, Abp, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,404 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AutoMapper.AbpAutoMapperModule, Abp.AutoMapper, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,405 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.EntityFrameworkCore.backendEntityFrameworkModule, backend.EntityFrameworkCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,405 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.EntityFrameworkCore.AbpZeroCoreEntityFrameworkCoreModule, Abp.ZeroCore.EntityFrameworkCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,406 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.EntityFrameworkCore.AbpEntityFrameworkCoreModule, Abp.EntityFrameworkCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,406 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.EntityFramework.AbpEntityFrameworkCommonModule, Abp.EntityFramework.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,407 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AspNetCore.AbpAspNetCoreModule, Abp.AspNetCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,410 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Web.AbpWebCommonModule, Abp.Web.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,411 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AspNetCore.SignalR.AbpAspNetCoreSignalRModule, Abp.AspNetCore.SignalR, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:18,413 [2    ] Abp.Modules.AbpModuleManager             - 15 modules loaded.
+DEBUG 2026-04-02 13:05:18,507 [2    ] o.Configuration.LanguageManagementConfig - Converted Abp (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 13:05:18,507 [2    ] o.Configuration.LanguageManagementConfig - Converted AbpZero (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 13:05:18,507 [2    ] o.Configuration.LanguageManagementConfig - Converted backend (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 13:05:18,507 [2    ] o.Configuration.LanguageManagementConfig - Converted AbpWeb (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 13:05:19,127 [2    ] ameworkCore.AbpEntityFrameworkCoreModule - Registering DbContext: backend.EntityFrameworkCore.backendDbContext, backend.EntityFrameworkCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:05:19,693 [2    ] Abp.Localization.LocalizationManager     - Initializing 4 localization sources.
+DEBUG 2026-04-02 13:05:19,821 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: Abp
+DEBUG 2026-04-02 13:05:19,848 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: AbpZero
+DEBUG 2026-04-02 13:05:19,893 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: backend
+DEBUG 2026-04-02 13:05:19,905 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: AbpWeb
+DEBUG 2026-04-02 13:05:19,928 [2    ] Abp.BackgroundJobs.BackgroundJobManager  - Start background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 13:05:19,935 [2    ] , Culture=neutral, PublicKeyToken=null]] - Start background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 13:05:19,970 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - Found 10 classes define auto mapping attributes
+DEBUG 2026-04-02 13:05:19,970 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Users.Dto.CreateUserDto
+DEBUG 2026-04-02 13:05:19,974 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Users.Dto.UserDto
+DEBUG 2026-04-02 13:05:19,976 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Sessions.Dto.TenantLoginInfoDto
+DEBUG 2026-04-02 13:05:19,976 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Sessions.Dto.UserLoginInfoDto
+DEBUG 2026-04-02 13:05:19,976 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.LegalDocumentService.DTO.LegalDocumentDto
+DEBUG 2026-04-02 13:05:19,977 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.LegalDocumentService.DTO.LegalDocumentListDto
+DEBUG 2026-04-02 13:05:19,977 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.CategoryService.DTO.CategoryDto
+DEBUG 2026-04-02 13:05:19,977 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Roles.Dto.PermissionDto
+DEBUG 2026-04-02 13:05:19,977 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.MultiTenancy.Dto.CreateTenantDto
+DEBUG 2026-04-02 13:05:19,977 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.MultiTenancy.Dto.TenantDto
+INFO  2026-04-02 13:05:41,352 [2    ] tCore.Builder.RequestLocalizationOptions - Supported Request Localization Cultures: en,es-MX,fr,de,it,nl,pt-BR,tr,ru,ar,fa,ja,zh-Hans
+INFO  2026-04-02 13:05:41,786 [2    ] Microsoft.Hosting.Lifetime               - Now listening on: https://localhost:44311
+INFO  2026-04-02 13:05:41,786 [2    ] Microsoft.Hosting.Lifetime               - Now listening on: http://localhost:21021
+INFO  2026-04-02 13:05:41,899 [2    ] Microsoft.Hosting.Lifetime               - Application started. Press Ctrl+C to shut down.
+INFO  2026-04-02 13:05:41,899 [2    ] Microsoft.Hosting.Lifetime               - Hosting environment: Development
+INFO  2026-04-02 13:05:41,899 [2    ] Microsoft.Hosting.Lifetime               - Content root path: C:\Users\Nhlakanipho\Documents\Projects\Mzansi-legal\backend\src\backend.Web.Host
+INFO  2026-04-02 13:05:42,275 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/ - - -
+INFO  2026-04-02 13:05:42,479 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host)'
+INFO  2026-04-02 13:05:42,524 [16   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "Index", controller = "Home", area = ""}. Executing controller action with signature Microsoft.AspNetCore.Mvc.IActionResult Index() on controller backend.Web.Host.Controllers.HomeController (backend.Web.Host).
+INFO  2026-04-02 13:05:44,267 [16   ] vc.Infrastructure.RedirectResultExecutor - Executing RedirectResult, redirecting to /swagger.
+INFO  2026-04-02 13:05:44,290 [16   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host) in 1744.9112ms
+INFO  2026-04-02 13:05:44,293 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host)'
+INFO  2026-04-02 13:05:44,312 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/ - 302 - - 2030.8159ms
+INFO  2026-04-02 13:05:44,379 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/_framework/aspnetcore-browser-refresh.js - - -
+INFO  2026-04-02 13:05:44,411 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/_vs/browserLink - - -
+INFO  2026-04-02 13:05:44,428 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/_framework/aspnetcore-browser-refresh.js - 200 14937 application/javascript;+charset=utf-8 48.7268ms
+INFO  2026-04-02 13:05:44,514 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/_vs/browserLink - 200 - text/javascript;+charset=UTF-8 102.2717ms
+INFO  2026-04-02 13:05:44,595 [18   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/AntiForgery/SetCookie - - -
+INFO  2026-04-02 13:05:44,753 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/swagger/v1/swagger.json - - -
+INFO  2026-04-02 13:05:48,188 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host)'
+INFO  2026-04-02 13:05:48,209 [8    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "SetCookie", controller = "AntiForgery", area = ""}. Executing controller action with signature Void SetCookie() on controller backend.Web.Host.Controllers.AntiForgeryController (backend.Web.Host).
+INFO  2026-04-02 13:05:48,440 [18   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/swagger/v1/swagger.json - 200 - application/json;charset=utf-8 3686.5241ms
+INFO  2026-04-02 13:05:49,708 [9    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:05:49,727 [9    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host) in 1518.5173ms
+INFO  2026-04-02 13:05:49,728 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host)'
+INFO  2026-04-02 13:05:49,728 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/AntiForgery/SetCookie - 200 - application/json;+charset=utf-8 5132.6736ms
+INFO  2026-04-02 13:06:04,702 [8    ] ckend.Web.Host.Startup.RagStartupService - [RagService] Chunk embeddings loaded into memory. RAG service is ready.
+INFO  2026-04-02 13:08:19,615 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:08:19,620 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:08:19,623 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 8.5640ms
+INFO  2026-04-02 13:08:19,627 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:08:19,627 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:08:20,735 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:08:20,807 [9    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+WARN  2026-04-02 13:08:21,025 [9    ] Microsoft.EntityFrameworkCore.Query      - Compiling a query which loads related collections for more than one collection navigation, either via 'Include' or through projection, but no 'QuerySplittingBehavior' has been configured. By default, Entity Framework will use 'QuerySplittingBehavior.SingleQuery', which can potentially result in slow query performance. See https://go.microsoft.com/fwlink/?linkid=2134277 for more information. To identify the query that's triggering this warning call 'ConfigureWarnings(w => w.Throw(RelationalEventId.MultipleCollectionIncludeWarning))'.
+INFO  2026-04-02 13:08:23,256 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:08:23,300 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2493.0358ms
+INFO  2026-04-02 13:08:23,300 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:08:23,300 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 3673.9335ms
+INFO  2026-04-02 13:14:32,968 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:14:32,968 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:14:32,969 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 1.1663ms
+INFO  2026-04-02 13:14:32,975 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:14:32,975 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:14:32,979 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:14:32,983 [20   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:14:37,216 [9    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:14:37,217 [9    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 4233.274ms
+INFO  2026-04-02 13:14:37,217 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:14:37,217 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 4242.1960ms
+INFO  2026-04-02 13:18:14,568 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:18:14,569 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:18:14,573 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 3.2597ms
+INFO  2026-04-02 13:18:14,574 [18   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:18:14,579 [18   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:18:14,584 [18   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 9.3382ms
+INFO  2026-04-02 13:18:14,590 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:18:14,591 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:18:14,599 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:18:14,599 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:18:14,599 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:18:14,616 [9    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:18:14,643 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 404 0 - 44.1716ms
+INFO  2026-04-02 13:18:14,649 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:21021/api/app/question/academy, Response status code: 404
+INFO  2026-04-02 13:18:16,768 [9    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:18:16,768 [9    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2151.8484ms
+INFO  2026-04-02 13:18:16,768 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:18:16,769 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2178.3758ms
+INFO  2026-04-02 13:18:44,535 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:18:44,535 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:18:44,536 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 0.9139ms
+INFO  2026-04-02 13:18:44,537 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:18:44,537 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:18:44,538 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 1.1210ms
+INFO  2026-04-02 13:18:44,539 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:18:44,539 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:18:44,540 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:18:44,545 [9    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:18:44,546 [18   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:18:44,546 [18   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:18:44,548 [18   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 404 0 - 2.1680ms
+INFO  2026-04-02 13:18:44,549 [18   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:21021/api/app/question/academy, Response status code: 404
+INFO  2026-04-02 13:18:44,962 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:18:44,963 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:18:44,967 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 404 0 - 3.7703ms
+INFO  2026-04-02 13:18:44,967 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:21021/api/app/question/academy, Response status code: 404
+INFO  2026-04-02 13:18:46,866 [9    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:18:46,866 [9    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2320.8711ms
+INFO  2026-04-02 13:18:46,866 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:18:46,867 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2327.5563ms
+INFO  2026-04-02 13:18:46,884 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:18:46,885 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:18:46,887 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:18:46,895 [9    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:18:49,133 [15   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:18:49,133 [15   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2237.5764ms
+INFO  2026-04-02 13:18:49,134 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:18:49,134 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2249.4404ms
+INFO  2026-04-02 13:19:58,550 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:19:58,550 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:19:58,551 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 0.9319ms
+INFO  2026-04-02 13:19:58,554 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:19:58,554 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:19:58,556 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:19:58,558 [20   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:19:58,559 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:19:58,560 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:19:58,560 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.8066ms
+INFO  2026-04-02 13:19:58,564 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:19:58,565 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:19:58,566 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 404 0 - 2.1459ms
+INFO  2026-04-02 13:19:58,566 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:21021/api/app/question/academy, Response status code: 404
+INFO  2026-04-02 13:19:59,109 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:19:59,109 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:19:59,112 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 404 0 - 3.3421ms
+INFO  2026-04-02 13:19:59,112 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:21021/api/app/question/academy, Response status code: 404
+INFO  2026-04-02 13:20:00,765 [20   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:20:00,766 [20   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2207.6361ms
+INFO  2026-04-02 13:20:00,766 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:20:00,766 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2212.1319ms
+INFO  2026-04-02 13:20:00,770 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:20:00,770 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:20:00,772 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:20:00,783 [20   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:20:02,996 [20   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:20:02,996 [20   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2212.5329ms
+INFO  2026-04-02 13:20:02,996 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:20:02,996 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2226.1203ms
+INFO  2026-04-02 13:20:48,954 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:20:48,954 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:20:48,954 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 0.5749ms
+INFO  2026-04-02 13:20:48,955 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:20:48,955 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:20:48,955 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.7464ms
+INFO  2026-04-02 13:20:48,958 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:20:48,958 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:20:48,958 [3    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:20:48,960 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:20:48,960 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 404 0 - 2.3441ms
+INFO  2026-04-02 13:20:48,960 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:21021/api/app/question/academy, Response status code: 404
+INFO  2026-04-02 13:20:48,960 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:20:48,963 [20   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:20:51,848 [16   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:20:51,848 [16   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2884.6168ms
+INFO  2026-04-02 13:20:51,848 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:20:51,848 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2890.5276ms
+INFO  2026-04-02 13:21:09,105 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:21:09,105 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:21:09,105 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 0.4490ms
+INFO  2026-04-02 13:21:09,110 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:21:09,110 [3    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:21:09,111 [3    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:21:09,117 [3    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:21:09,157 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:21:09,157 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:21:09,158 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.3731ms
+INFO  2026-04-02 13:21:09,163 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:21:09,164 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:21:09,164 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 404 0 - 1.1219ms
+INFO  2026-04-02 13:21:09,165 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:21021/api/app/question/academy, Response status code: 404
+INFO  2026-04-02 13:21:11,836 [8    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:21:11,837 [8    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2720.151ms
+INFO  2026-04-02 13:21:11,837 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:21:11,838 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2727.7626ms
+DEBUG 2026-04-02 13:29:09,099 [16   ] Abp.Modules.AbpModuleManager             - Shutting down has been started
+DEBUG 2026-04-02 13:29:09,103 [16   ] Abp.BackgroundJobs.BackgroundJobManager  - Stop background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 13:29:09,103 [16   ] , Culture=neutral, PublicKeyToken=null]] - Stop background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 13:29:09,104 [16   ] Abp.BackgroundJobs.BackgroundJobManager  - WaitToStop background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 13:29:09,104 [16   ] , Culture=neutral, PublicKeyToken=null]] - WaitToStop background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 13:29:09,104 [16   ] Abp.Modules.AbpModuleManager             - Shutting down completed.
+INFO  2026-04-02 13:29:09,104 [16   ] Microsoft.Hosting.Lifetime               - Application is shutting down...
+DEBUG 2026-04-02 13:29:35,754 [2    ] Abp.Modules.AbpModuleManager             - Loading Abp modules...
+DEBUG 2026-04-02 13:29:35,768 [2    ] Abp.Modules.AbpModuleManager             - Found 15 ABP modules in total.
+DEBUG 2026-04-02 13:29:35,782 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.Web.Host.Startup.backendWebHostModule, backend.Web.Host, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,784 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendWebCoreModule, backend.Web.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,784 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendApplicationModule, backend.Application, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,784 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendCoreModule, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,785 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.AbpZeroCoreModule, Abp.ZeroCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,785 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.AbpZeroCommonModule, Abp.Zero.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,785 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AbpKernelModule, Abp, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,785 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AutoMapper.AbpAutoMapperModule, Abp.AutoMapper, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,786 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.EntityFrameworkCore.backendEntityFrameworkModule, backend.EntityFrameworkCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,786 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.EntityFrameworkCore.AbpZeroCoreEntityFrameworkCoreModule, Abp.ZeroCore.EntityFrameworkCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,786 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.EntityFrameworkCore.AbpEntityFrameworkCoreModule, Abp.EntityFrameworkCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,786 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.EntityFramework.AbpEntityFrameworkCommonModule, Abp.EntityFramework.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,786 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AspNetCore.AbpAspNetCoreModule, Abp.AspNetCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,786 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Web.AbpWebCommonModule, Abp.Web.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,787 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AspNetCore.SignalR.AbpAspNetCoreSignalRModule, Abp.AspNetCore.SignalR, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:35,788 [2    ] Abp.Modules.AbpModuleManager             - 15 modules loaded.
+DEBUG 2026-04-02 13:29:35,867 [2    ] o.Configuration.LanguageManagementConfig - Converted Abp (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 13:29:35,867 [2    ] o.Configuration.LanguageManagementConfig - Converted AbpZero (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 13:29:35,867 [2    ] o.Configuration.LanguageManagementConfig - Converted backend (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 13:29:35,867 [2    ] o.Configuration.LanguageManagementConfig - Converted AbpWeb (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 13:29:36,105 [2    ] ameworkCore.AbpEntityFrameworkCoreModule - Registering DbContext: backend.EntityFrameworkCore.backendDbContext, backend.EntityFrameworkCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:29:36,271 [2    ] Abp.Localization.LocalizationManager     - Initializing 4 localization sources.
+DEBUG 2026-04-02 13:29:36,303 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: Abp
+DEBUG 2026-04-02 13:29:36,311 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: AbpZero
+DEBUG 2026-04-02 13:29:36,315 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: backend
+DEBUG 2026-04-02 13:29:36,319 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: AbpWeb
+DEBUG 2026-04-02 13:29:36,325 [2    ] Abp.BackgroundJobs.BackgroundJobManager  - Start background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 13:29:36,327 [2    ] , Culture=neutral, PublicKeyToken=null]] - Start background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 13:29:36,341 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - Found 10 classes define auto mapping attributes
+DEBUG 2026-04-02 13:29:36,341 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Users.Dto.CreateUserDto
+DEBUG 2026-04-02 13:29:36,343 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Users.Dto.UserDto
+DEBUG 2026-04-02 13:29:36,343 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Sessions.Dto.TenantLoginInfoDto
+DEBUG 2026-04-02 13:29:36,343 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Sessions.Dto.UserLoginInfoDto
+DEBUG 2026-04-02 13:29:36,343 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.LegalDocumentService.DTO.LegalDocumentDto
+DEBUG 2026-04-02 13:29:36,344 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.LegalDocumentService.DTO.LegalDocumentListDto
+DEBUG 2026-04-02 13:29:36,344 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.CategoryService.DTO.CategoryDto
+DEBUG 2026-04-02 13:29:36,344 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Roles.Dto.PermissionDto
+DEBUG 2026-04-02 13:29:36,344 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.MultiTenancy.Dto.CreateTenantDto
+DEBUG 2026-04-02 13:29:36,344 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.MultiTenancy.Dto.TenantDto
+INFO  2026-04-02 13:29:55,599 [2    ] tCore.Builder.RequestLocalizationOptions - Supported Request Localization Cultures: en,es-MX,fr,de,it,nl,pt-BR,tr,ru,ar,fa,ja,zh-Hans
+INFO  2026-04-02 13:29:55,809 [2    ] Microsoft.Hosting.Lifetime               - Now listening on: https://localhost:44311
+INFO  2026-04-02 13:29:55,809 [2    ] Microsoft.Hosting.Lifetime               - Now listening on: http://localhost:21021
+INFO  2026-04-02 13:29:55,854 [2    ] Microsoft.Hosting.Lifetime               - Application started. Press Ctrl+C to shut down.
+INFO  2026-04-02 13:29:55,854 [2    ] Microsoft.Hosting.Lifetime               - Hosting environment: Development
+INFO  2026-04-02 13:29:55,854 [2    ] Microsoft.Hosting.Lifetime               - Content root path: C:\Users\Nhlakanipho\Documents\Projects\Mzansi-legal\backend\src\backend.Web.Host
+INFO  2026-04-02 13:29:56,646 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/ - - -
+INFO  2026-04-02 13:29:57,091 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host)'
+INFO  2026-04-02 13:29:57,173 [8    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "Index", controller = "Home", area = ""}. Executing controller action with signature Microsoft.AspNetCore.Mvc.IActionResult Index() on controller backend.Web.Host.Controllers.HomeController (backend.Web.Host).
+INFO  2026-04-02 13:29:58,898 [8    ] vc.Infrastructure.RedirectResultExecutor - Executing RedirectResult, redirecting to /swagger.
+INFO  2026-04-02 13:29:58,919 [8    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host) in 1725.5626ms
+INFO  2026-04-02 13:29:58,920 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host)'
+INFO  2026-04-02 13:29:58,937 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/ - 302 - - 2289.2464ms
+INFO  2026-04-02 13:29:59,136 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/_framework/aspnetcore-browser-refresh.js - - -
+INFO  2026-04-02 13:29:59,147 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/_vs/browserLink - - -
+INFO  2026-04-02 13:29:59,149 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/_framework/aspnetcore-browser-refresh.js - 200 14937 application/javascript;+charset=utf-8 12.7123ms
+INFO  2026-04-02 13:29:59,188 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/_vs/browserLink - 200 - text/javascript;+charset=UTF-8 40.6504ms
+INFO  2026-04-02 13:29:59,260 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/AntiForgery/SetCookie - - -
+INFO  2026-04-02 13:29:59,299 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/swagger/v1/swagger.json - - -
+INFO  2026-04-02 13:30:00,104 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host)'
+INFO  2026-04-02 13:30:00,110 [16   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "SetCookie", controller = "AntiForgery", area = ""}. Executing controller action with signature Void SetCookie() on controller backend.Web.Host.Controllers.AntiForgeryController (backend.Web.Host).
+INFO  2026-04-02 13:30:00,196 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/swagger/v1/swagger.json - 200 - application/json;charset=utf-8 897.2329ms
+INFO  2026-04-02 13:30:01,517 [8    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:30:01,525 [8    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host) in 1414.625ms
+INFO  2026-04-02 13:30:01,525 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host)'
+INFO  2026-04-02 13:30:01,525 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/AntiForgery/SetCookie - 200 - application/json;+charset=utf-8 2265.0705ms
+INFO  2026-04-02 13:30:25,455 [20   ] ckend.Web.Host.Startup.RagStartupService - [RagService] Chunk embeddings loaded into memory. RAG service is ready.
+INFO  2026-04-02 13:30:38,486 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:30:38,486 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:30:38,492 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:30:38,492 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:30:38,495 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 8.9146ms
+INFO  2026-04-02 13:30:38,495 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 8.9145ms
+INFO  2026-04-02 13:30:38,498 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:30:38,498 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:30:38,498 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:30:38,498 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:30:39,611 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:30:39,618 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:30:39,632 [20   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:30:39,648 [16   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+WARN  2026-04-02 13:30:39,848 [16   ] Microsoft.EntityFrameworkCore.Query      - Compiling a query which loads related collections for more than one collection navigation, either via 'Include' or through projection, but no 'QuerySplittingBehavior' has been configured. By default, Entity Framework will use 'QuerySplittingBehavior.SingleQuery', which can potentially result in slow query performance. See https://go.microsoft.com/fwlink/?linkid=2134277 for more information. To identify the query that's triggering this warning call 'ConfigureWarnings(w => w.Throw(RelationalEventId.MultipleCollectionIncludeWarning))'.
+INFO  2026-04-02 13:30:42,414 [8    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:30:42,437 [8    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2788.4274ms
+INFO  2026-04-02 13:30:42,437 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:30:42,437 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 3939.5838ms
+INFO  2026-04-02 13:30:43,952 [20   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:30:43,970 [20   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 4337.6339ms
+INFO  2026-04-02 13:30:43,970 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:30:43,970 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 5472.5971ms
+INFO  2026-04-02 13:33:49,042 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:33:49,043 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:33:49,043 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 0.7819ms
+INFO  2026-04-02 13:33:49,046 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:33:49,046 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:33:49,052 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:33:49,052 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:33:49,052 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:33:49,053 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.3805ms
+INFO  2026-04-02 13:33:49,056 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:33:49,056 [8    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:33:49,056 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:33:49,057 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:33:49,060 [16   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:33:51,338 [10   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:33:51,339 [10   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2282.678ms
+INFO  2026-04-02 13:33:51,339 [10   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:33:51,339 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2292.9890ms
+INFO  2026-04-02 13:33:56,046 [16   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:33:56,047 [16   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 6986.5131ms
+INFO  2026-04-02 13:33:56,047 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:33:56,047 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 6991.4367ms
+INFO  2026-04-02 13:36:25,606 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/qa/ask - - -
+INFO  2026-04-02 13:36:25,607 [10   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:36:25,607 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/qa/ask - 204 - - 0.5719ms
+INFO  2026-04-02 13:36:25,613 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 POST http://localhost:21021/api/app/qa/ask - application/json 116
+INFO  2026-04-02 13:36:25,613 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:36:25,614 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QaController.Ask (backend.Web.Host)'
+INFO  2026-04-02 13:36:25,645 [16   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "Ask", controller = "Qa", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RagService.DTO.RagAnswerResult] Ask(backend.Services.RagService.DTO.AskQuestionRequest) on controller backend.Web.Host.Controllers.QaController (backend.Web.Host).
+INFO  2026-04-02 13:36:26,138 [16   ] et.Http.HttpClient.OpenAI.LogicalHandler - Start processing HTTP request POST https://api.openai.com/v1/chat/completions
+INFO  2026-04-02 13:36:26,139 [16   ] Net.Http.HttpClient.OpenAI.ClientHandler - Sending HTTP request POST https://api.openai.com/v1/chat/completions
+INFO  2026-04-02 13:36:27,740 [19   ] Net.Http.HttpClient.OpenAI.ClientHandler - Received HTTP response headers after 1585.4761ms - 200
+INFO  2026-04-02 13:36:27,742 [19   ] et.Http.HttpClient.OpenAI.LogicalHandler - End processing HTTP request after 1606.4183ms - 200
+INFO  2026-04-02 13:36:27,768 [19   ] et.Http.HttpClient.OpenAI.LogicalHandler - Start processing HTTP request POST https://api.openai.com/v1/embeddings
+INFO  2026-04-02 13:36:27,768 [19   ] Net.Http.HttpClient.OpenAI.ClientHandler - Sending HTTP request POST https://api.openai.com/v1/embeddings
+INFO  2026-04-02 13:36:30,510 [16   ] Net.Http.HttpClient.OpenAI.ClientHandler - Received HTTP response headers after 2741.7141ms - 200
+INFO  2026-04-02 13:36:30,510 [16   ] et.Http.HttpClient.OpenAI.LogicalHandler - End processing HTTP request after 2742.1754ms - 200
+INFO  2026-04-02 13:36:30,541 [16   ] et.Http.HttpClient.OpenAI.LogicalHandler - Start processing HTTP request POST https://api.openai.com/v1/embeddings
+INFO  2026-04-02 13:36:30,542 [16   ] Net.Http.HttpClient.OpenAI.ClientHandler - Sending HTTP request POST https://api.openai.com/v1/embeddings
+INFO  2026-04-02 13:36:32,899 [16   ] Net.Http.HttpClient.OpenAI.ClientHandler - Received HTTP response headers after 2357.2467ms - 200
+INFO  2026-04-02 13:36:32,899 [16   ] et.Http.HttpClient.OpenAI.LogicalHandler - End processing HTTP request after 2357.9436ms - 200
+INFO  2026-04-02 13:36:34,467 [16   ] et.Http.HttpClient.OpenAI.LogicalHandler - Start processing HTTP request POST https://api.openai.com/v1/chat/completions
+INFO  2026-04-02 13:36:34,467 [16   ] Net.Http.HttpClient.OpenAI.ClientHandler - Sending HTTP request POST https://api.openai.com/v1/chat/completions
+INFO  2026-04-02 13:36:41,153 [19   ] Net.Http.HttpClient.OpenAI.ClientHandler - Received HTTP response headers after 6685.5355ms - 200
+INFO  2026-04-02 13:36:41,153 [19   ] et.Http.HttpClient.OpenAI.LogicalHandler - End processing HTTP request after 6686.0693ms - 200
+INFO  2026-04-02 13:36:44,705 [10   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:36:44,731 [10   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QaController.Ask (backend.Web.Host) in 19086.1907ms
+INFO  2026-04-02 13:36:44,731 [10   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QaController.Ask (backend.Web.Host)'
+INFO  2026-04-02 13:36:44,734 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 POST http://localhost:21021/api/app/qa/ask - 200 - application/json;+charset=utf-8 19120.7202ms
+INFO  2026-04-02 13:37:50,133 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 13:37:50,134 [10   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:37:50,135 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - 204 - - 1.5525ms
+INFO  2026-04-02 13:37:50,137 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 13:37:50,137 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:37:50,138 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - 204 - - 0.8418ms
+INFO  2026-04-02 13:37:50,139 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 13:37:50,139 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:37:50,141 [6    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 13:37:50,148 [6    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetMy", controller = "Contract", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.ContractService.DTO.ContractAnalysisListDto] GetMy() on controller backend.Web.Host.Controllers.ContractController (backend.Web.Host).
+INFO  2026-04-02 13:37:53,716 [6    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:37:53,724 [6    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host) in 3575.5416ms
+INFO  2026-04-02 13:37:53,724 [6    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 13:37:53,725 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/contract/my - 200 - application/json;+charset=utf-8 3586.1659ms
+INFO  2026-04-02 13:37:53,730 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 13:37:53,731 [10   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:37:53,733 [10   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 13:37:53,736 [10   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetMy", controller = "Contract", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.ContractService.DTO.ContractAnalysisListDto] GetMy() on controller backend.Web.Host.Controllers.ContractController (backend.Web.Host).
+INFO  2026-04-02 13:37:56,966 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:37:56,967 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host) in 3230.6592ms
+INFO  2026-04-02 13:37:56,967 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 13:37:56,967 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/contract/my - 200 - application/json;+charset=utf-8 3237.2195ms
+INFO  2026-04-02 13:38:10,699 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/019d4d7e-294f-7c29-9887-a4619acd4b28 - - -
+INFO  2026-04-02 13:38:10,700 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:38:10,700 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/019d4d7e-294f-7c29-9887-a4619acd4b28 - 204 - - 1.2545ms
+INFO  2026-04-02 13:38:10,701 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/019d4d7e-294f-7c29-9887-a4619acd4b28 - - -
+INFO  2026-04-02 13:38:10,701 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:38:10,701 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/019d4d7e-294f-7c29-9887-a4619acd4b28 - 204 - - 0.3301ms
+INFO  2026-04-02 13:38:10,703 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/contract/019d4d7e-294f-7c29-9887-a4619acd4b28 - - -
+INFO  2026-04-02 13:38:10,704 [10   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:38:10,705 [10   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.ContractController.Get (backend.Web.Host)'
+INFO  2026-04-02 13:38:10,724 [10   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "Get", controller = "Contract", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.ContractService.DTO.ContractAnalysisDto] Get(System.Guid) on controller backend.Web.Host.Controllers.ContractController (backend.Web.Host).
+INFO  2026-04-02 13:38:13,366 [10   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:38:13,381 [10   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.ContractController.Get (backend.Web.Host) in 2657.2862ms
+INFO  2026-04-02 13:38:13,381 [10   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.ContractController.Get (backend.Web.Host)'
+INFO  2026-04-02 13:38:13,383 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/contract/019d4d7e-294f-7c29-9887-a4619acd4b28 - 200 - application/json;+charset=utf-8 2678.0625ms
+INFO  2026-04-02 13:38:13,392 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/contract/019d4d7e-294f-7c29-9887-a4619acd4b28 - - -
+INFO  2026-04-02 13:38:13,392 [10   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:38:13,393 [10   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.ContractController.Get (backend.Web.Host)'
+INFO  2026-04-02 13:38:13,395 [10   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "Get", controller = "Contract", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.ContractService.DTO.ContractAnalysisDto] Get(System.Guid) on controller backend.Web.Host.Controllers.ContractController (backend.Web.Host).
+INFO  2026-04-02 13:38:15,995 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:38:15,997 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.ContractController.Get (backend.Web.Host) in 2601.215ms
+INFO  2026-04-02 13:38:15,997 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.ContractController.Get (backend.Web.Host)'
+INFO  2026-04-02 13:38:15,998 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/contract/019d4d7e-294f-7c29-9887-a4619acd4b28 - 200 - application/json;+charset=utf-8 2606.4441ms
+INFO  2026-04-02 13:38:30,626 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:38:30,626 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:38:30,627 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 0.6916ms
+INFO  2026-04-02 13:38:30,631 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:38:30,631 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:38:30,631 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:38:30,631 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:38:30,631 [10   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:38:30,631 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:38:30,631 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 0.2213ms
+INFO  2026-04-02 13:38:30,631 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.4106ms
+INFO  2026-04-02 13:38:30,631 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:38:30,632 [10   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:38:30,631 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.1586ms
+INFO  2026-04-02 13:38:30,632 [10   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:38:30,634 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:38:30,634 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:38:30,635 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:38:30,636 [10   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:38:30,637 [19   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:38:32,748 [6    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:38:32,748 [6    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2112.6943ms
+INFO  2026-04-02 13:38:32,749 [6    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:38:32,749 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2117.2652ms
+INFO  2026-04-02 13:38:32,762 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:38:32,762 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:38:32,763 [6    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:38:32,808 [6    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:38:34,901 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:38:34,902 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2093.8497ms
+INFO  2026-04-02 13:38:34,902 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:38:34,902 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2140.3738ms
+INFO  2026-04-02 13:38:35,011 [6    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:38:35,012 [6    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 4374.8472ms
+INFO  2026-04-02 13:38:35,012 [6    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:38:35,013 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 4378.8972ms
+INFO  2026-04-02 13:38:35,015 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:38:35,015 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:38:35,018 [6    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:38:35,022 [6    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:38:40,251 [6    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:38:40,251 [6    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 5228.5235ms
+INFO  2026-04-02 13:38:40,251 [6    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:38:40,251 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 5236.5704ms
+INFO  2026-04-02 13:39:01,326 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:39:01,326 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:39:01,326 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.4518ms
+INFO  2026-04-02 13:39:01,326 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:39:01,326 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:39:01,326 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.2513ms
+INFO  2026-04-02 13:39:01,329 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:39:01,329 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:39:01,330 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:39:01,336 [19   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:39:06,069 [16   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:39:06,070 [16   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 4733.9966ms
+INFO  2026-04-02 13:39:06,070 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:39:06,071 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 4742.0549ms
+INFO  2026-04-02 13:39:06,086 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:39:06,087 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:39:06,087 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:39:06,094 [19   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:39:12,846 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:39:12,846 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 6751.8262ms
+INFO  2026-04-02 13:39:12,846 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:39:12,847 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 6760.5032ms
+INFO  2026-04-02 13:39:27,127 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:39:27,127 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:39:27,127 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 0.4931ms
+INFO  2026-04-02 13:39:27,128 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:39:27,128 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:39:27,128 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.2746ms
+INFO  2026-04-02 13:39:27,128 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:39:27,129 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:39:27,129 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 0.1831ms
+INFO  2026-04-02 13:39:27,138 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:39:27,138 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:39:27,138 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.3803ms
+INFO  2026-04-02 13:39:27,141 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:39:27,141 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:39:27,142 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:39:27,153 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:39:27,154 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:39:27,154 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:39:27,157 [16   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:39:27,170 [19   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:39:29,299 [3    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:39:29,299 [3    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2142.0954ms
+INFO  2026-04-02 13:39:29,299 [3    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:39:29,300 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2158.7383ms
+INFO  2026-04-02 13:39:29,309 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:39:29,309 [3    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:39:29,310 [3    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:39:29,315 [3    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:39:31,384 [3    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:39:31,385 [3    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 4214.9544ms
+INFO  2026-04-02 13:39:31,385 [3    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:39:31,386 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 4232.8126ms
+INFO  2026-04-02 13:39:31,388 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:39:31,389 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2071.3669ms
+INFO  2026-04-02 13:39:31,389 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:39:31,390 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2081.0139ms
+INFO  2026-04-02 13:39:31,397 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:39:31,399 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:39:31,404 [6    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:39:31,435 [6    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:39:35,252 [16   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:39:35,253 [16   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 3817.2264ms
+INFO  2026-04-02 13:39:35,253 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:39:35,253 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 3855.8582ms
+INFO  2026-04-02 13:42:00,382 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:42:00,382 [21   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:42:00,382 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.4004ms
+INFO  2026-04-02 13:42:00,383 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:42:00,384 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:42:00,385 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:42:00,385 [21   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:42:00,386 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 2.8517ms
+INFO  2026-04-02 13:42:00,386 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:42:00,391 [16   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:42:04,961 [16   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:42:04,962 [16   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 4570.3688ms
+INFO  2026-04-02 13:42:04,962 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:42:04,962 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 4577.5379ms
+INFO  2026-04-02 13:42:04,965 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:42:04,965 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:42:04,966 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:42:04,969 [16   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:42:08,595 [16   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:42:08,599 [16   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 3629.1497ms
+INFO  2026-04-02 13:42:08,599 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:42:08,599 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 3634.4140ms
+INFO  2026-04-02 13:52:43,868 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:52:43,882 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:52:43,890 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 19.6177ms
+INFO  2026-04-02 13:52:43,895 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:52:43,901 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:52:44,000 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:52:44,113 [20   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:52:46,362 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:52:46,362 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:52:46,362 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.4000ms
+INFO  2026-04-02 13:52:46,368 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:52:46,369 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:52:46,482 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 404 0 - 114.0143ms
+INFO  2026-04-02 13:52:46,503 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:21021/api/app/question/academy-progress, Response status code: 404
+INFO  2026-04-02 13:52:49,241 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:52:49,241 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:52:49,241 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.4139ms
+INFO  2026-04-02 13:52:49,249 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:52:49,250 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:52:49,255 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 404 0 - 5.4378ms
+INFO  2026-04-02 13:52:49,255 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request reached the end of the middleware pipeline without being handled by application code. Request path: GET http://localhost:21021/api/app/question/academy-progress, Response status code: 404
+INFO  2026-04-02 13:52:49,811 [20   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:52:49,818 [20   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 5705.0186ms
+INFO  2026-04-02 13:52:49,818 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:52:49,819 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 5923.6279ms
+INFO  2026-04-02 13:52:49,830 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:52:49,830 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:52:49,831 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:52:49,839 [20   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:52:53,866 [20   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:52:53,866 [20   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 4027.273ms
+INFO  2026-04-02 13:52:53,866 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:52:53,866 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 4037.4582ms
+DEBUG 2026-04-02 13:54:27,080 [19   ] Abp.Modules.AbpModuleManager             - Shutting down has been started
+DEBUG 2026-04-02 13:54:27,087 [19   ] Abp.BackgroundJobs.BackgroundJobManager  - Stop background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 13:54:27,088 [19   ] , Culture=neutral, PublicKeyToken=null]] - Stop background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 13:54:27,089 [19   ] Abp.BackgroundJobs.BackgroundJobManager  - WaitToStop background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 13:54:27,089 [19   ] , Culture=neutral, PublicKeyToken=null]] - WaitToStop background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 13:54:27,089 [19   ] Abp.Modules.AbpModuleManager             - Shutting down completed.
+INFO  2026-04-02 13:54:27,090 [19   ] Microsoft.Hosting.Lifetime               - Application is shutting down...
+DEBUG 2026-04-02 13:57:15,385 [2    ] Abp.Modules.AbpModuleManager             - Loading Abp modules...
+DEBUG 2026-04-02 13:57:15,394 [2    ] Abp.Modules.AbpModuleManager             - Found 15 ABP modules in total.
+DEBUG 2026-04-02 13:57:15,406 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.Web.Host.Startup.backendWebHostModule, backend.Web.Host, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,407 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendWebCoreModule, backend.Web.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,408 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendApplicationModule, backend.Application, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,408 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendCoreModule, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,408 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.AbpZeroCoreModule, Abp.ZeroCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,408 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.AbpZeroCommonModule, Abp.Zero.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,408 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AbpKernelModule, Abp, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,409 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AutoMapper.AbpAutoMapperModule, Abp.AutoMapper, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,409 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.EntityFrameworkCore.backendEntityFrameworkModule, backend.EntityFrameworkCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,409 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.EntityFrameworkCore.AbpZeroCoreEntityFrameworkCoreModule, Abp.ZeroCore.EntityFrameworkCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,409 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.EntityFrameworkCore.AbpEntityFrameworkCoreModule, Abp.EntityFrameworkCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,410 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.EntityFramework.AbpEntityFrameworkCommonModule, Abp.EntityFramework.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,410 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AspNetCore.AbpAspNetCoreModule, Abp.AspNetCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,410 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Web.AbpWebCommonModule, Abp.Web.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,410 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AspNetCore.SignalR.AbpAspNetCoreSignalRModule, Abp.AspNetCore.SignalR, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,411 [2    ] Abp.Modules.AbpModuleManager             - 15 modules loaded.
+DEBUG 2026-04-02 13:57:15,448 [2    ] o.Configuration.LanguageManagementConfig - Converted Abp (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 13:57:15,448 [2    ] o.Configuration.LanguageManagementConfig - Converted AbpZero (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 13:57:15,448 [2    ] o.Configuration.LanguageManagementConfig - Converted backend (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 13:57:15,448 [2    ] o.Configuration.LanguageManagementConfig - Converted AbpWeb (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 13:57:15,677 [2    ] ameworkCore.AbpEntityFrameworkCoreModule - Registering DbContext: backend.EntityFrameworkCore.backendDbContext, backend.EntityFrameworkCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 13:57:15,880 [2    ] Abp.Localization.LocalizationManager     - Initializing 4 localization sources.
+DEBUG 2026-04-02 13:57:15,913 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: Abp
+DEBUG 2026-04-02 13:57:15,919 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: AbpZero
+DEBUG 2026-04-02 13:57:15,924 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: backend
+DEBUG 2026-04-02 13:57:15,926 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: AbpWeb
+DEBUG 2026-04-02 13:57:15,932 [2    ] Abp.BackgroundJobs.BackgroundJobManager  - Start background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 13:57:15,934 [2    ] , Culture=neutral, PublicKeyToken=null]] - Start background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 13:57:15,948 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - Found 10 classes define auto mapping attributes
+DEBUG 2026-04-02 13:57:15,948 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Users.Dto.CreateUserDto
+DEBUG 2026-04-02 13:57:15,950 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Users.Dto.UserDto
+DEBUG 2026-04-02 13:57:15,951 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Sessions.Dto.TenantLoginInfoDto
+DEBUG 2026-04-02 13:57:15,951 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Sessions.Dto.UserLoginInfoDto
+DEBUG 2026-04-02 13:57:15,951 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.LegalDocumentService.DTO.LegalDocumentDto
+DEBUG 2026-04-02 13:57:15,951 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.LegalDocumentService.DTO.LegalDocumentListDto
+DEBUG 2026-04-02 13:57:15,951 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.CategoryService.DTO.CategoryDto
+DEBUG 2026-04-02 13:57:15,951 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Roles.Dto.PermissionDto
+DEBUG 2026-04-02 13:57:15,951 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.MultiTenancy.Dto.CreateTenantDto
+DEBUG 2026-04-02 13:57:15,951 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.MultiTenancy.Dto.TenantDto
+INFO  2026-04-02 13:57:40,074 [2    ] tCore.Builder.RequestLocalizationOptions - Supported Request Localization Cultures: en,es-MX,fr,de,it,nl,pt-BR,tr,ru,ar,fa,ja,zh-Hans
+INFO  2026-04-02 13:57:40,279 [2    ] Microsoft.Hosting.Lifetime               - Now listening on: https://localhost:44311
+INFO  2026-04-02 13:57:40,279 [2    ] Microsoft.Hosting.Lifetime               - Now listening on: http://localhost:21021
+INFO  2026-04-02 13:57:40,321 [2    ] Microsoft.Hosting.Lifetime               - Application started. Press Ctrl+C to shut down.
+INFO  2026-04-02 13:57:40,322 [2    ] Microsoft.Hosting.Lifetime               - Hosting environment: Development
+INFO  2026-04-02 13:57:40,322 [2    ] Microsoft.Hosting.Lifetime               - Content root path: C:\Users\Nhlakanipho\Documents\Projects\Mzansi-legal\backend\src\backend.Web.Host
+INFO  2026-04-02 13:57:41,154 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/ - - -
+INFO  2026-04-02 13:57:41,259 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host)'
+INFO  2026-04-02 13:57:41,277 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "Index", controller = "Home", area = ""}. Executing controller action with signature Microsoft.AspNetCore.Mvc.IActionResult Index() on controller backend.Web.Host.Controllers.HomeController (backend.Web.Host).
+INFO  2026-04-02 13:57:44,995 [8    ] vc.Infrastructure.RedirectResultExecutor - Executing RedirectResult, redirecting to /swagger.
+INFO  2026-04-02 13:57:45,006 [8    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host) in 3719.3246ms
+INFO  2026-04-02 13:57:45,006 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host)'
+INFO  2026-04-02 13:57:45,012 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/ - 302 - - 3857.7269ms
+INFO  2026-04-02 13:57:45,188 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/_framework/aspnetcore-browser-refresh.js - - -
+INFO  2026-04-02 13:57:45,194 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/_framework/aspnetcore-browser-refresh.js - 200 14937 application/javascript;+charset=utf-8 5.6882ms
+INFO  2026-04-02 13:57:45,204 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/_vs/browserLink - - -
+INFO  2026-04-02 13:57:45,237 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/_vs/browserLink - 200 - text/javascript;+charset=UTF-8 33.4331ms
+INFO  2026-04-02 13:57:45,400 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/AntiForgery/SetCookie - - -
+INFO  2026-04-02 13:57:45,402 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host)'
+INFO  2026-04-02 13:57:45,404 [15   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "SetCookie", controller = "AntiForgery", area = ""}. Executing controller action with signature Void SetCookie() on controller backend.Web.Host.Controllers.AntiForgeryController (backend.Web.Host).
+INFO  2026-04-02 13:57:45,455 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/swagger/v1/swagger.json - - -
+INFO  2026-04-02 13:57:45,491 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/swagger/v1/swagger.json - 200 - application/json;charset=utf-8 36.3254ms
+INFO  2026-04-02 13:57:47,040 [9    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:57:47,044 [9    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host) in 1639.1287ms
+INFO  2026-04-02 13:57:47,044 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host)'
+INFO  2026-04-02 13:57:47,044 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/AntiForgery/SetCookie - 200 - application/json;+charset=utf-8 1643.7747ms
+INFO  2026-04-02 13:58:05,957 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:58:05,960 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:58:05,973 [17   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:05,974 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:05,984 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 26.0499ms
+INFO  2026-04-02 13:58:05,993 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 32.1506ms
+INFO  2026-04-02 13:58:05,995 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:58:05,996 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:58:05,997 [17   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:06,004 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:07,513 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:58:07,523 [17   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:58:07,540 [17   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:58:07,572 [15   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:58:09,714 [17   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:58:09,717 [17   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 2144.9697ms
+INFO  2026-04-02 13:58:09,717 [17   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:58:09,718 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 3722.8934ms
+INFO  2026-04-02 13:58:09,780 [15   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:58:09,805 [15   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 2264.3811ms
+INFO  2026-04-02 13:58:09,805 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:58:09,806 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 3809.2948ms
+INFO  2026-04-02 13:58:14,821 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:58:14,821 [17   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:14,821 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.5987ms
+INFO  2026-04-02 13:58:14,826 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 PUT http://localhost:21021/api/app/question/academy-progress - application/json 104
+INFO  2026-04-02 13:58:14,827 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:14,842 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.UpdateAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:58:14,861 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "UpdateAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] UpdateAcademyProgress(backend.Services.RightsExplorerService.DTO.UpdateRightsAcademyProgressInput) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:58:18,780 [9    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:58:18,781 [9    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.UpdateAcademyProgress (backend.Web.Host) in 3919.8282ms
+INFO  2026-04-02 13:58:18,782 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.UpdateAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:58:18,785 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 PUT http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 3958.3887ms
+INFO  2026-04-02 13:58:20,140 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:58:20,140 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:20,141 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 0.6037ms
+INFO  2026-04-02 13:58:20,142 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:58:20,142 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:20,143 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:58:20,143 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 1.2087ms
+INFO  2026-04-02 13:58:20,143 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:20,143 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.5465ms
+INFO  2026-04-02 13:58:20,145 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:58:20,145 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:20,146 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:58:20,147 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:20,147 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:58:20,147 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:20,831 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:58:20,831 [17   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:58:20,831 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:58:20,835 [15   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:58:20,837 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:58:20,853 [17   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:58:22,214 [15   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:58:22,214 [15   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1379.4075ms
+INFO  2026-04-02 13:58:22,214 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:58:22,215 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 2067.9309ms
+INFO  2026-04-02 13:58:22,231 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:58:22,232 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:22,232 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:58:22,245 [9    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:58:22,468 [8    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:58:22,469 [8    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1627.5605ms
+INFO  2026-04-02 13:58:22,469 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:58:22,469 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 2323.7344ms
+INFO  2026-04-02 13:58:22,473 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:58:22,473 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:22,474 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:58:22,478 [8    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+WARN  2026-04-02 13:58:23,218 [17   ] Microsoft.EntityFrameworkCore.Query      - Compiling a query which loads related collections for more than one collection navigation, either via 'Include' or through projection, but no 'QuerySplittingBehavior' has been configured. By default, Entity Framework will use 'QuerySplittingBehavior.SingleQuery', which can potentially result in slow query performance. See https://go.microsoft.com/fwlink/?linkid=2134277 for more information. To identify the query that's triggering this warning call 'ConfigureWarnings(w => w.Throw(RelationalEventId.MultipleCollectionIncludeWarning))'.
+INFO  2026-04-02 13:58:23,654 [9    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:58:23,654 [9    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1409.1811ms
+INFO  2026-04-02 13:58:23,654 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:58:23,655 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1423.2518ms
+INFO  2026-04-02 13:58:24,117 [9    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:58:24,120 [9    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1642.0396ms
+INFO  2026-04-02 13:58:24,120 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:58:24,121 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1647.4062ms
+INFO  2026-04-02 13:58:25,515 [13   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:58:25,545 [13   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 4691.9136ms
+INFO  2026-04-02 13:58:25,545 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:58:25,545 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 5400.5428ms
+INFO  2026-04-02 13:58:25,549 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 13:58:25,550 [17   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:25,553 [17   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:58:25,566 [17   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:58:27,768 [15   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:58:27,768 [15   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2202.3019ms
+INFO  2026-04-02 13:58:27,768 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:58:27,769 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2219.2705ms
+INFO  2026-04-02 13:58:32,809 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:58:32,809 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:58:32,809 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:32,809 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.3188ms
+INFO  2026-04-02 13:58:32,810 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:58:32,810 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:32,810 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.2288ms
+INFO  2026-04-02 13:58:32,810 [17   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:32,810 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:58:32,810 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:32,810 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 2.0202ms
+INFO  2026-04-02 13:58:32,810 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.2193ms
+INFO  2026-04-02 13:58:32,812 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:58:32,812 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:32,813 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:58:32,813 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:32,813 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:58:32,814 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:58:32,816 [20   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:58:32,816 [15   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:58:34,184 [15   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:58:34,184 [15   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1368.1018ms
+INFO  2026-04-02 13:58:34,184 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:58:34,185 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1371.6535ms
+INFO  2026-04-02 13:58:34,190 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:58:34,190 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:34,191 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:58:34,193 [15   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:58:34,448 [20   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:58:34,449 [20   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1632.3865ms
+INFO  2026-04-02 13:58:34,449 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:58:34,449 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1636.9316ms
+INFO  2026-04-02 13:58:34,452 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:58:34,453 [17   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:34,453 [17   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:58:34,455 [17   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:58:34,579 [13   ] ckend.Web.Host.Startup.RagStartupService - [RagService] Chunk embeddings loaded into memory. RAG service is ready.
+INFO  2026-04-02 13:58:35,579 [15   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:58:35,579 [15   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1386.0913ms
+INFO  2026-04-02 13:58:35,579 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:58:35,579 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1389.6707ms
+INFO  2026-04-02 13:58:35,846 [17   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:58:35,848 [17   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1392.2826ms
+INFO  2026-04-02 13:58:35,848 [17   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:58:35,849 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1397.0087ms
+INFO  2026-04-02 13:58:38,950 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:58:38,951 [17   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:38,951 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.4598ms
+INFO  2026-04-02 13:58:38,956 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 PUT http://localhost:21021/api/app/question/academy-progress - application/json 137
+INFO  2026-04-02 13:58:38,957 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:38,958 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.UpdateAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:58:38,968 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "UpdateAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] UpdateAcademyProgress(backend.Services.RightsExplorerService.DTO.UpdateRightsAcademyProgressInput) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:58:42,828 [13   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:58:42,828 [13   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.UpdateAcademyProgress (backend.Web.Host) in 3859.3451ms
+INFO  2026-04-02 13:58:42,828 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.UpdateAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:58:42,828 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 PUT http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 3872.1630ms
+INFO  2026-04-02 13:58:59,095 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 13:58:59,095 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:59,096 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - 204 - - 0.5072ms
+INFO  2026-04-02 13:58:59,096 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 13:58:59,096 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:59,096 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - 204 - - 0.2442ms
+INFO  2026-04-02 13:58:59,097 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 13:58:59,098 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:58:59,918 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 13:58:59,944 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetMy", controller = "Contract", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.ContractService.DTO.ContractAnalysisListDto] GetMy() on controller backend.Web.Host.Controllers.ContractController (backend.Web.Host).
+INFO  2026-04-02 13:59:01,094 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=zu - - -
+INFO  2026-04-02 13:59:01,095 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:59:01,095 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:01,095 [17   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:01,095 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=zu - 204 - - 0.7714ms
+INFO  2026-04-02 13:59:01,095 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.6493ms
+INFO  2026-04-02 13:59:01,096 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:59:01,097 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:01,097 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.3694ms
+INFO  2026-04-02 13:59:01,097 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=zu - - -
+INFO  2026-04-02 13:59:01,097 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=zu - - -
+INFO  2026-04-02 13:59:01,097 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:01,097 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:01,097 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=zu - 204 - - 0.2133ms
+INFO  2026-04-02 13:59:01,098 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:59:01,098 [14   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:59:01,098 [14   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:01,099 [14   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.2729ms
+INFO  2026-04-02 13:59:01,099 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:59:01,099 [14   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:59:01,099 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:01,099 [14   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:01,100 [14   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:59:01,100 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:59:01,101 [15   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:59:01,102 [14   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:59:01,105 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:59:02,483 [15   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:59:02,486 [15   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1382.649ms
+INFO  2026-04-02 13:59:02,488 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:59:02,495 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1391.6163ms
+INFO  2026-04-02 13:59:02,496 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:59:02,501 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:02,512 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:59:02,533 [15   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:59:02,737 [13   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:59:02,737 [13   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1632.0979ms
+INFO  2026-04-02 13:59:02,737 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:59:02,738 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1638.8732ms
+INFO  2026-04-02 13:59:02,745 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:59:02,746 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:02,746 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:59:02,757 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:59:03,361 [14   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:59:03,361 [14   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2260.074ms
+INFO  2026-04-02 13:59:03,362 [14   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:59:03,362 [14   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=zu - 200 - application/json;+charset=utf-8 2264.7020ms
+INFO  2026-04-02 13:59:03,367 [14   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=zu - - -
+INFO  2026-04-02 13:59:03,368 [14   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:03,369 [14   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:59:03,371 [14   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:59:03,506 [15   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:59:03,564 [15   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host) in 3619.1978ms
+INFO  2026-04-02 13:59:03,564 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 13:59:03,570 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/contract/my - 200 - application/json;+charset=utf-8 4472.8195ms
+INFO  2026-04-02 13:59:03,571 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 13:59:03,571 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:03,579 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 13:59:03,588 [15   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetMy", controller = "Contract", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.ContractService.DTO.ContractAnalysisListDto] GetMy() on controller backend.Web.Host.Controllers.ContractController (backend.Web.Host).
+INFO  2026-04-02 13:59:03,924 [13   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:59:03,926 [13   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1391.571ms
+INFO  2026-04-02 13:59:03,926 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:59:03,928 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1431.9269ms
+INFO  2026-04-02 13:59:04,141 [15   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:59:04,141 [15   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1383.5669ms
+INFO  2026-04-02 13:59:04,141 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:59:04,141 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1395.8298ms
+INFO  2026-04-02 13:59:05,576 [20   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:59:05,578 [20   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2207.265ms
+INFO  2026-04-02 13:59:05,579 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 13:59:05,584 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=zu - 200 - application/json;+charset=utf-8 2216.2853ms
+INFO  2026-04-02 13:59:06,153 [13   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:59:06,154 [13   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host) in 2565.7213ms
+INFO  2026-04-02 13:59:06,154 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 13:59:06,154 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/contract/my - 200 - application/json;+charset=utf-8 2583.4895ms
+INFO  2026-04-02 13:59:11,962 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:59:11,962 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:11,962 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.3795ms
+INFO  2026-04-02 13:59:11,963 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:59:11,963 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:11,963 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.1596ms
+INFO  2026-04-02 13:59:11,963 [14   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:59:11,963 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:59:11,963 [14   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:11,963 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:11,963 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.1507ms
+INFO  2026-04-02 13:59:11,963 [14   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.4647ms
+INFO  2026-04-02 13:59:11,967 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:59:11,968 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:11,968 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:59:11,969 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:59:11,969 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:11,970 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:59:11,972 [20   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:59:11,977 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:59:13,346 [13   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:59:13,347 [13   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1374.8757ms
+INFO  2026-04-02 13:59:13,347 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:59:13,347 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1380.0158ms
+INFO  2026-04-02 13:59:13,354 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 13:59:13,354 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:13,355 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:59:13,358 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:59:13,599 [14   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:59:13,600 [14   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1622.7176ms
+INFO  2026-04-02 13:59:13,600 [14   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:59:13,600 [14   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1630.7964ms
+INFO  2026-04-02 13:59:13,604 [14   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 13:59:13,604 [14   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 13:59:13,607 [14   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:59:13,619 [14   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 13:59:14,756 [14   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:59:14,756 [14   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1397.4847ms
+INFO  2026-04-02 13:59:14,756 [14   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 13:59:14,756 [14   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1402.4035ms
+INFO  2026-04-02 13:59:14,995 [13   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 13:59:14,996 [13   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1376.1298ms
+INFO  2026-04-02 13:59:14,996 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 13:59:14,996 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1392.1090ms
+INFO  2026-04-02 14:03:23,139 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:03:23,140 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:03:23,142 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:03:23,142 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:03:23,144 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 5.1707ms
+INFO  2026-04-02 14:03:23,144 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 5.7924ms
+INFO  2026-04-02 14:03:23,146 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:03:23,147 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:03:23,153 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:03:23,154 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:03:23,161 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:03:23,161 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:03:23,182 [20   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:03:23,183 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:03:24,606 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:03:24,607 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1423.2754ms
+INFO  2026-04-02 14:03:24,607 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:03:24,607 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1453.8105ms
+INFO  2026-04-02 14:03:26,705 [13   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:03:26,705 [13   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 3522.8794ms
+INFO  2026-04-02 14:03:26,706 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:03:26,706 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 3559.5199ms
+INFO  2026-04-02 14:07:52,013 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:07:52,013 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:07:52,013 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.4636ms
+INFO  2026-04-02 14:07:52,016 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:07:52,016 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:07:52,021 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:07:52,031 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:07:52,049 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:07:52,050 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:07:52,050 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.5623ms
+INFO  2026-04-02 14:07:52,054 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:07:52,054 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:07:52,056 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:07:52,071 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:07:53,431 [13   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:07:53,431 [13   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1400.2443ms
+INFO  2026-04-02 14:07:53,431 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:07:53,432 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1415.5040ms
+INFO  2026-04-02 14:07:54,080 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:07:54,080 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:07:54,081 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:07:54,088 [19   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:07:55,469 [13   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:07:55,471 [13   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1382.2568ms
+INFO  2026-04-02 14:07:55,471 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:07:55,471 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1391.4004ms
+INFO  2026-04-02 14:07:55,822 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:07:55,822 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 3751.1791ms
+INFO  2026-04-02 14:07:55,822 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:07:55,823 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 3769.0083ms
+INFO  2026-04-02 14:07:55,830 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:07:55,830 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:07:55,832 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:07:55,837 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:07:57,219 [13   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:07:57,219 [13   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1382.1792ms
+INFO  2026-04-02 14:07:57,219 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:07:57,220 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1389.9295ms
+INFO  2026-04-02 14:08:07,039 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:08:07,040 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:08:07,040 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 1.4402ms
+INFO  2026-04-02 14:08:07,043 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:08:07,043 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:08:07,048 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:08:07,051 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:08:07,136 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:08:07,137 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:08:07,137 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 1.3860ms
+INFO  2026-04-02 14:08:07,140 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:08:07,140 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:08:07,141 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:08:07,144 [20   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:08:08,425 [13   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:08:08,425 [13   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1374.2733ms
+INFO  2026-04-02 14:08:08,425 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:08:08,426 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1382.4999ms
+INFO  2026-04-02 14:08:08,539 [20   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:08:08,539 [20   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1394.6813ms
+INFO  2026-04-02 14:08:08,539 [20   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:08:08,540 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1400.1889ms
+INFO  2026-04-02 14:08:33,037 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:08:33,038 [20   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:08:33,038 [20   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.8459ms
+INFO  2026-04-02 14:08:33,041 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:08:33,041 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:08:33,042 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:08:33,045 [13   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:08:33,056 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:08:33,056 [13   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:08:33,056 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.4291ms
+INFO  2026-04-02 14:08:33,064 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:08:33,064 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:08:33,065 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:08:33,070 [19   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:08:34,557 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:08:34,557 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1486.6757ms
+INFO  2026-04-02 14:08:34,557 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:08:34,558 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1493.8521ms
+INFO  2026-04-02 14:08:34,609 [13   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:08:34,610 [13   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1564.4631ms
+INFO  2026-04-02 14:08:34,610 [13   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:08:34,610 [13   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1569.1842ms
+DEBUG 2026-04-02 14:13:35,198 [3    ] Abp.Modules.AbpModuleManager             - Shutting down has been started
+DEBUG 2026-04-02 14:13:35,209 [3    ] Abp.BackgroundJobs.BackgroundJobManager  - Stop background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 14:13:35,210 [3    ] , Culture=neutral, PublicKeyToken=null]] - Stop background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 14:13:35,211 [3    ] Abp.BackgroundJobs.BackgroundJobManager  - WaitToStop background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 14:13:35,211 [3    ] , Culture=neutral, PublicKeyToken=null]] - WaitToStop background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 14:13:35,211 [3    ] Abp.Modules.AbpModuleManager             - Shutting down completed.
+INFO  2026-04-02 14:13:35,213 [3    ] Microsoft.Hosting.Lifetime               - Application is shutting down...
+DEBUG 2026-04-02 14:14:43,383 [2    ] Abp.Modules.AbpModuleManager             - Loading Abp modules...
+DEBUG 2026-04-02 14:14:43,393 [2    ] Abp.Modules.AbpModuleManager             - Found 15 ABP modules in total.
+DEBUG 2026-04-02 14:14:43,403 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.Web.Host.Startup.backendWebHostModule, backend.Web.Host, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,405 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendWebCoreModule, backend.Web.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,405 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendApplicationModule, backend.Application, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,405 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendCoreModule, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,406 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.AbpZeroCoreModule, Abp.ZeroCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,406 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.AbpZeroCommonModule, Abp.Zero.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,406 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AbpKernelModule, Abp, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,407 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AutoMapper.AbpAutoMapperModule, Abp.AutoMapper, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,407 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.EntityFrameworkCore.backendEntityFrameworkModule, backend.EntityFrameworkCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,407 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.EntityFrameworkCore.AbpZeroCoreEntityFrameworkCoreModule, Abp.ZeroCore.EntityFrameworkCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,407 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.EntityFrameworkCore.AbpEntityFrameworkCoreModule, Abp.EntityFrameworkCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,408 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.EntityFramework.AbpEntityFrameworkCommonModule, Abp.EntityFramework.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,408 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AspNetCore.AbpAspNetCoreModule, Abp.AspNetCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,408 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Web.AbpWebCommonModule, Abp.Web.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,408 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AspNetCore.SignalR.AbpAspNetCoreSignalRModule, Abp.AspNetCore.SignalR, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:43,409 [2    ] Abp.Modules.AbpModuleManager             - 15 modules loaded.
+DEBUG 2026-04-02 14:14:43,450 [2    ] o.Configuration.LanguageManagementConfig - Converted Abp (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 14:14:43,451 [2    ] o.Configuration.LanguageManagementConfig - Converted AbpZero (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 14:14:43,451 [2    ] o.Configuration.LanguageManagementConfig - Converted backend (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 14:14:43,451 [2    ] o.Configuration.LanguageManagementConfig - Converted AbpWeb (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 14:14:43,704 [2    ] ameworkCore.AbpEntityFrameworkCoreModule - Registering DbContext: backend.EntityFrameworkCore.backendDbContext, backend.EntityFrameworkCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:14:44,017 [2    ] Abp.Localization.LocalizationManager     - Initializing 4 localization sources.
+DEBUG 2026-04-02 14:14:44,048 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: Abp
+DEBUG 2026-04-02 14:14:44,057 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: AbpZero
+DEBUG 2026-04-02 14:14:44,063 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: backend
+DEBUG 2026-04-02 14:14:44,069 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: AbpWeb
+DEBUG 2026-04-02 14:14:44,078 [2    ] Abp.BackgroundJobs.BackgroundJobManager  - Start background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 14:14:44,082 [2    ] , Culture=neutral, PublicKeyToken=null]] - Start background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 14:14:44,105 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - Found 10 classes define auto mapping attributes
+DEBUG 2026-04-02 14:14:44,105 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Users.Dto.CreateUserDto
+DEBUG 2026-04-02 14:14:44,108 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Users.Dto.UserDto
+DEBUG 2026-04-02 14:14:44,109 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Sessions.Dto.TenantLoginInfoDto
+DEBUG 2026-04-02 14:14:44,109 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Sessions.Dto.UserLoginInfoDto
+DEBUG 2026-04-02 14:14:44,109 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.LegalDocumentService.DTO.LegalDocumentDto
+DEBUG 2026-04-02 14:14:44,109 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.LegalDocumentService.DTO.LegalDocumentListDto
+DEBUG 2026-04-02 14:14:44,109 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.CategoryService.DTO.CategoryDto
+DEBUG 2026-04-02 14:14:44,109 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Roles.Dto.PermissionDto
+DEBUG 2026-04-02 14:14:44,109 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.MultiTenancy.Dto.CreateTenantDto
+DEBUG 2026-04-02 14:14:44,109 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.MultiTenancy.Dto.TenantDto
+INFO  2026-04-02 14:15:05,887 [2    ] tCore.Builder.RequestLocalizationOptions - Supported Request Localization Cultures: en,es-MX,fr,de,it,nl,pt-BR,tr,ru,ar,fa,ja,zh-Hans
+INFO  2026-04-02 14:15:06,124 [2    ] Microsoft.Hosting.Lifetime               - Now listening on: https://localhost:44311
+INFO  2026-04-02 14:15:06,124 [2    ] Microsoft.Hosting.Lifetime               - Now listening on: http://localhost:21021
+INFO  2026-04-02 14:15:06,155 [2    ] Microsoft.Hosting.Lifetime               - Application started. Press Ctrl+C to shut down.
+INFO  2026-04-02 14:15:06,156 [2    ] Microsoft.Hosting.Lifetime               - Hosting environment: Development
+INFO  2026-04-02 14:15:06,156 [2    ] Microsoft.Hosting.Lifetime               - Content root path: C:\Users\Nhlakanipho\Documents\Projects\Mzansi-legal\backend\src\backend.Web.Host
+INFO  2026-04-02 14:15:06,711 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/ - - -
+INFO  2026-04-02 14:15:06,944 [6    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host)'
+INFO  2026-04-02 14:15:06,992 [6    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "Index", controller = "Home", area = ""}. Executing controller action with signature Microsoft.AspNetCore.Mvc.IActionResult Index() on controller backend.Web.Host.Controllers.HomeController (backend.Web.Host).
+INFO  2026-04-02 14:15:09,069 [17   ] vc.Infrastructure.RedirectResultExecutor - Executing RedirectResult, redirecting to /swagger.
+INFO  2026-04-02 14:15:09,092 [17   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host) in 2079.4249ms
+INFO  2026-04-02 14:15:09,094 [17   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host)'
+INFO  2026-04-02 14:15:09,107 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/ - 302 - - 2397.5665ms
+INFO  2026-04-02 14:15:09,280 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/_framework/aspnetcore-browser-refresh.js - - -
+INFO  2026-04-02 14:15:09,282 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/_vs/browserLink - - -
+INFO  2026-04-02 14:15:09,441 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/_framework/aspnetcore-browser-refresh.js - 200 14937 application/javascript;+charset=utf-8 159.4853ms
+INFO  2026-04-02 14:15:09,717 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/_vs/browserLink - 200 - text/javascript;+charset=UTF-8 433.8498ms
+INFO  2026-04-02 14:15:16,711 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/AntiForgery/SetCookie - - -
+INFO  2026-04-02 14:15:16,715 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host)'
+INFO  2026-04-02 14:15:16,730 [16   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "SetCookie", controller = "AntiForgery", area = ""}. Executing controller action with signature Void SetCookie() on controller backend.Web.Host.Controllers.AntiForgeryController (backend.Web.Host).
+INFO  2026-04-02 14:15:17,652 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/swagger/v1/swagger.json - - -
+INFO  2026-04-02 14:15:17,750 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/swagger/v1/swagger.json - 200 - application/json;charset=utf-8 97.7960ms
+INFO  2026-04-02 14:15:18,480 [16   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:15:18,488 [16   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host) in 1757.2683ms
+INFO  2026-04-02 14:15:18,489 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host)'
+INFO  2026-04-02 14:15:18,489 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/AntiForgery/SetCookie - 200 - application/json;+charset=utf-8 1777.5936ms
+INFO  2026-04-02 14:15:38,810 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:15:38,810 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:15:38,820 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:15:38,821 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:15:38,826 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 15.5262ms
+INFO  2026-04-02 14:15:38,831 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 14.6408ms
+INFO  2026-04-02 14:15:38,831 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:15:38,831 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:15:38,832 [17   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:15:38,832 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:15:40,219 [17   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:15:40,231 [17   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:15:40,974 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:15:41,033 [16   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:15:41,972 [22   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:15:41,976 [22   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1744.934ms
+INFO  2026-04-02 14:15:41,976 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:15:41,983 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 3150.7921ms
+INFO  2026-04-02 14:15:42,603 [15   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:15:42,626 [15   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1585.8565ms
+INFO  2026-04-02 14:15:42,626 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:15:42,627 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 3795.1672ms
+INFO  2026-04-02 14:15:57,275 [22   ] ckend.Web.Host.Startup.RagStartupService - [RagService] Chunk embeddings loaded into memory. RAG service is ready.
+INFO  2026-04-02 14:17:27,806 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:17:27,806 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:17:27,807 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.7316ms
+INFO  2026-04-02 14:17:27,807 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:17:27,807 [15   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:17:27,809 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 1.7462ms
+INFO  2026-04-02 14:17:27,811 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:17:27,811 [22   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:17:27,819 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:17:27,819 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:17:27,820 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:17:27,820 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:17:27,823 [19   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:17:27,823 [22   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:17:29,259 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:17:29,260 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1436.6142ms
+INFO  2026-04-02 14:17:29,262 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:17:29,263 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1443.7736ms
+INFO  2026-04-02 14:17:29,271 [16   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:17:29,273 [16   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1449.6169ms
+INFO  2026-04-02 14:17:29,273 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:17:29,274 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1462.8192ms
+INFO  2026-04-02 14:17:36,241 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:17:36,242 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:17:36,242 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.6542ms
+INFO  2026-04-02 14:17:36,248 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:17:36,248 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:17:36,249 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:17:36,254 [16   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:17:36,804 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:17:36,804 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:17:36,804 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.4578ms
+INFO  2026-04-02 14:17:36,817 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:17:36,817 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:17:36,818 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:17:36,821 [16   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:17:37,688 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:17:37,688 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1433.8839ms
+INFO  2026-04-02 14:17:37,688 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:17:37,689 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1440.8998ms
+INFO  2026-04-02 14:17:38,249 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:17:38,249 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1427.801ms
+INFO  2026-04-02 14:17:38,249 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:17:38,249 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1432.3120ms
+INFO  2026-04-02 14:20:15,210 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:20:15,211 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:20:15,211 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 1.1520ms
+INFO  2026-04-02 14:20:15,214 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:20:15,214 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:20:15,215 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.4725ms
+INFO  2026-04-02 14:20:15,215 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:20:15,216 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:20:15,217 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:20:15,218 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:20:15,219 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:20:15,220 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:20:15,221 [19   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:20:15,222 [16   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:20:16,652 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:20:16,652 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1431.4352ms
+INFO  2026-04-02 14:20:16,652 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:20:16,653 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1437.3193ms
+INFO  2026-04-02 14:20:19,217 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:20:19,218 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 3995.3357ms
+INFO  2026-04-02 14:20:19,218 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:20:19,218 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 3999.9088ms
+INFO  2026-04-02 14:20:35,851 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:20:35,852 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:20:35,852 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.9116ms
+INFO  2026-04-02 14:20:35,860 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 PUT http://localhost:21021/api/app/question/academy-progress - application/json 177
+INFO  2026-04-02 14:20:35,860 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:20:35,907 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.UpdateAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:20:36,836 [19   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "UpdateAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] UpdateAcademyProgress(backend.Services.RightsExplorerService.DTO.UpdateRightsAcademyProgressInput) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:20:45,444 [16   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:20:45,444 [16   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.UpdateAcademyProgress (backend.Web.Host) in 8607.9793ms
+INFO  2026-04-02 14:20:45,444 [16   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.UpdateAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:20:45,444 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 PUT http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 9584.8709ms
+INFO  2026-04-02 14:21:25,410 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:21:25,410 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:21:25,411 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.7024ms
+INFO  2026-04-02 14:21:25,411 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:21:25,411 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:21:25,411 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.2353ms
+INFO  2026-04-02 14:21:25,472 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:21:25,473 [16   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:21:25,495 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:21:25,496 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:21:26,174 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:21:26,174 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:21:26,176 [22   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:21:26,178 [19   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:21:27,558 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:21:27,559 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1382.1552ms
+INFO  2026-04-02 14:21:27,559 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:21:27,559 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 2086.6888ms
+INFO  2026-04-02 14:21:30,003 [19   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:21:30,003 [19   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 3825.1602ms
+INFO  2026-04-02 14:21:30,003 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:21:30,004 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 4508.0908ms
+INFO  2026-04-02 14:22:28,020 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:22:28,020 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:22:28,020 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.6014ms
+INFO  2026-04-02 14:22:28,022 [19   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:22:28,023 [19   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:22:28,024 [19   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:22:28,027 [19   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:22:28,031 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:22:28,032 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:22:28,032 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.9055ms
+INFO  2026-04-02 14:22:28,035 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:22:28,035 [22   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:22:28,036 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:22:28,040 [22   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:22:29,408 [9    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:22:29,409 [9    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1382.1467ms
+INFO  2026-04-02 14:22:29,409 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:22:29,409 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1386.6878ms
+INFO  2026-04-02 14:22:29,426 [21   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:22:29,427 [21   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1386.718ms
+INFO  2026-04-02 14:22:29,427 [21   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:22:29,427 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1392.3937ms
+INFO  2026-04-02 14:23:00,091 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=zu - - -
+INFO  2026-04-02 14:23:00,092 [22   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:23:00,092 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=zu - 204 - - 0.5675ms
+INFO  2026-04-02 14:23:00,094 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:23:00,095 [21   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:23:00,096 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 1.5817ms
+INFO  2026-04-02 14:23:00,097 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:23:00,097 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:23:00,097 [21   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:23:00,097 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.6663ms
+INFO  2026-04-02 14:23:00,098 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=zu - - -
+INFO  2026-04-02 14:23:00,098 [21   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:23:00,099 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:23:00,099 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:23:00,100 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.8856ms
+INFO  2026-04-02 14:23:00,100 [22   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:23:00,101 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 4.1110ms
+INFO  2026-04-02 14:23:00,101 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:23:00,101 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:23:00,103 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:23:00,104 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=zu - - -
+INFO  2026-04-02 14:23:00,104 [3    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:23:00,104 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=zu - 204 - - 0.3886ms
+INFO  2026-04-02 14:23:00,106 [9    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:23:00,114 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:23:00,115 [22   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:23:00,115 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:23:00,119 [22   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:23:00,122 [21   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 14:23:00,146 [21   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+WARN  2026-04-02 14:23:00,376 [21   ] Microsoft.EntityFrameworkCore.Query      - Compiling a query which loads related collections for more than one collection navigation, either via 'Include' or through projection, but no 'QuerySplittingBehavior' has been configured. By default, Entity Framework will use 'QuerySplittingBehavior.SingleQuery', which can potentially result in slow query performance. See https://go.microsoft.com/fwlink/?linkid=2134277 for more information. To identify the query that's triggering this warning call 'ConfigureWarnings(w => w.Throw(RelationalEventId.MultipleCollectionIncludeWarning))'.
+INFO  2026-04-02 14:23:01,520 [21   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:23:01,521 [21   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1415.6023ms
+INFO  2026-04-02 14:23:01,521 [21   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:23:01,523 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1421.1127ms
+INFO  2026-04-02 14:23:01,530 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:23:01,531 [21   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:23:01,536 [22   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:23:01,537 [22   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1417.5646ms
+INFO  2026-04-02 14:23:01,537 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:23:01,537 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1422.6910ms
+INFO  2026-04-02 14:23:01,538 [21   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:23:01,540 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:23:01,540 [22   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:23:01,543 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:23:01,546 [21   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:23:01,547 [22   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:23:02,537 [22   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:23:02,608 [22   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2460.7369ms
+INFO  2026-04-02 14:23:02,608 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 14:23:02,608 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=zu - 200 - application/json;+charset=utf-8 2510.4611ms
+INFO  2026-04-02 14:23:02,610 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=zu - - -
+INFO  2026-04-02 14:23:02,610 [22   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:23:02,612 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 14:23:02,634 [22   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:23:02,927 [21   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:23:02,928 [21   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1381.698ms
+INFO  2026-04-02 14:23:02,928 [21   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:23:02,928 [21   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1398.4272ms
+INFO  2026-04-02 14:23:02,952 [9    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:23:02,952 [9    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1405.1233ms
+INFO  2026-04-02 14:23:02,952 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:23:02,953 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1412.8428ms
+INFO  2026-04-02 14:23:04,730 [22   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:23:04,731 [22   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2096.688ms
+INFO  2026-04-02 14:23:04,731 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 14:23:04,731 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=zu - 200 - application/json;+charset=utf-8 2120.6710ms
+INFO  2026-04-02 14:24:25,719 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=zu - - -
+INFO  2026-04-02 14:24:25,720 [3    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:24:25,720 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:24:25,720 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=zu - 204 - - 0.4541ms
+INFO  2026-04-02 14:24:25,720 [17   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:24:25,720 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.2297ms
+INFO  2026-04-02 14:24:25,722 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=zu - - -
+INFO  2026-04-02 14:24:25,722 [3    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:24:25,722 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:24:25,723 [22   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:24:25,723 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:24:25,723 [3    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 14:24:25,725 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:24:25,725 [17   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:24:25,725 [17   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.1999ms
+INFO  2026-04-02 14:24:25,726 [22   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:24:25,726 [3    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:24:25,728 [24   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:24:25,728 [24   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:24:25,728 [24   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:24:25,731 [24   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:24:27,103 [3    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:24:27,104 [3    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1377.6264ms
+INFO  2026-04-02 14:24:27,104 [3    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:24:27,104 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1381.5835ms
+INFO  2026-04-02 14:24:27,136 [6    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:24:27,137 [6    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1406.2456ms
+INFO  2026-04-02 14:24:27,137 [6    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:24:27,137 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1409.3925ms
+INFO  2026-04-02 14:24:27,781 [6    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:24:27,781 [6    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2054.8667ms
+INFO  2026-04-02 14:24:27,781 [6    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 14:24:27,781 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=zu - 200 - application/json;+charset=utf-8 2059.0949ms
+INFO  2026-04-02 14:25:13,801 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=st - - -
+INFO  2026-04-02 14:25:13,802 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:25:13,802 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:13,802 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=st - 204 - - 0.3715ms
+INFO  2026-04-02 14:25:13,802 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:25:13,802 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:13,802 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.1821ms
+INFO  2026-04-02 14:25:13,802 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:13,803 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.9749ms
+INFO  2026-04-02 14:25:13,804 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=st - - -
+INFO  2026-04-02 14:25:13,805 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:13,805 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=st - 204 - - 0.7441ms
+INFO  2026-04-02 14:25:13,806 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=st - - -
+INFO  2026-04-02 14:25:13,806 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:13,808 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:25:13,808 [22   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:13,809 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:25:13,809 [3    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:13,810 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:25:13,814 [3    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:25:13,814 [22   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:25:13,815 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 14:25:13,816 [3    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:25:13,818 [8    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:25:16,296 [8    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:25:16,296 [8    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2478.7843ms
+INFO  2026-04-02 14:25:16,296 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 14:25:16,297 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=st - 200 - application/json;+charset=utf-8 2491.0199ms
+INFO  2026-04-02 14:25:16,304 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=st - - -
+INFO  2026-04-02 14:25:16,304 [22   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:16,305 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 14:25:16,325 [22   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:25:18,487 [22   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:25:18,487 [22   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2162.418ms
+INFO  2026-04-02 14:25:18,487 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 14:25:18,487 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=st - 200 - application/json;+charset=utf-8 2183.1865ms
+INFO  2026-04-02 14:25:19,036 [22   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:25:19,036 [22   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 5220.5529ms
+INFO  2026-04-02 14:25:19,036 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:25:19,036 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 5227.6111ms
+INFO  2026-04-02 14:25:19,039 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:25:19,040 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:19,041 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:25:19,045 [8    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:25:19,685 [8    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:25:19,685 [8    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 5871.3112ms
+INFO  2026-04-02 14:25:19,685 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:25:19,685 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 5877.4238ms
+INFO  2026-04-02 14:25:19,697 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:25:19,697 [22   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:19,698 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:25:19,733 [22   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:25:20,465 [3    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:25:20,466 [3    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1420.1168ms
+INFO  2026-04-02 14:25:20,466 [3    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:25:20,466 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1426.4121ms
+INFO  2026-04-02 14:25:21,866 [3    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:25:21,866 [3    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 2133.0044ms
+INFO  2026-04-02 14:25:21,866 [3    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:25:21,866 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 2169.6286ms
+INFO  2026-04-02 14:25:50,173 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 14:25:50,174 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:50,174 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 1.0712ms
+INFO  2026-04-02 14:25:50,174 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:25:50,174 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:50,174 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.2177ms
+INFO  2026-04-02 14:25:50,174 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:25:50,175 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 14:25:50,175 [8    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:50,176 [22   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:50,176 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 1.2021ms
+INFO  2026-04-02 14:25:50,176 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/faqs?languageCode=en - 204 - - 0.7627ms
+INFO  2026-04-02 14:25:50,177 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:25:50,178 [3    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:50,178 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy - 204 - - 0.2980ms
+INFO  2026-04-02 14:25:50,178 [26   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:25:50,178 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:25:50,178 [26   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:50,178 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 14:25:50,178 [26   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/question/academy-progress - 204 - - 0.4939ms
+INFO  2026-04-02 14:25:50,178 [26   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:25:50,179 [3    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:50,179 [26   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:50,179 [22   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:50,180 [3    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:25:50,180 [26   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:25:50,181 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 14:25:50,187 [26   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:25:50,189 [3    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:25:50,192 [22   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:25:51,573 [22   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:25:51,575 [22   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1387.9695ms
+INFO  2026-04-02 14:25:51,575 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:25:51,575 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1396.5734ms
+INFO  2026-04-02 14:25:51,579 [26   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - - -
+INFO  2026-04-02 14:25:51,580 [26   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:51,582 [26   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:25:51,585 [26   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademyProgress", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyProgressDto] GetAcademyProgress() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:25:51,612 [3    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:25:51,613 [3    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1423.5034ms
+INFO  2026-04-02 14:25:51,613 [3    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:25:51,614 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1435.6062ms
+INFO  2026-04-02 14:25:51,617 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/academy - - -
+INFO  2026-04-02 14:25:51,617 [3    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:51,618 [3    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:25:51,622 [3    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetAcademy", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RightsExplorerService.DTO.RightsAcademyDto] GetAcademy() on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:25:52,403 [22   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:25:52,403 [22   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2210.9816ms
+INFO  2026-04-02 14:25:52,403 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 14:25:52,404 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2225.7585ms
+INFO  2026-04-02 14:25:52,406 [22   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - - -
+INFO  2026-04-02 14:25:52,407 [22   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:25:52,409 [22   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 14:25:52,413 [22   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetFaqs", controller = "Question", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.FaqService.DTO.PublicFaqListDto] GetFaqs(System.Nullable`1[System.Guid], System.String) on controller backend.Web.Host.Controllers.QuestionController (backend.Web.Host).
+INFO  2026-04-02 14:25:52,980 [26   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:25:52,981 [26   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host) in 1358.6481ms
+INFO  2026-04-02 14:25:52,981 [26   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademy (backend.Web.Host)'
+INFO  2026-04-02 14:25:52,981 [26   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy - 200 - application/json;+charset=utf-8 1364.4374ms
+INFO  2026-04-02 14:25:53,202 [3    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:25:53,203 [3    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host) in 1617.1399ms
+INFO  2026-04-02 14:25:53,203 [3    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetAcademyProgress (backend.Web.Host)'
+INFO  2026-04-02 14:25:53,203 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/academy-progress - 200 - application/json;+charset=utf-8 1623.7375ms
+INFO  2026-04-02 14:25:54,490 [3    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:25:54,490 [3    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host) in 2077.0203ms
+INFO  2026-04-02 14:25:54,491 [3    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QuestionController.GetFaqs (backend.Web.Host)'
+INFO  2026-04-02 14:25:54,491 [3    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/question/faqs?languageCode=en - 200 - application/json;+charset=utf-8 2084.6304ms
+DEBUG 2026-04-02 14:31:56,982 [24   ] Abp.Modules.AbpModuleManager             - Shutting down has been started
+DEBUG 2026-04-02 14:31:56,998 [24   ] Abp.BackgroundJobs.BackgroundJobManager  - Stop background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 14:31:57,000 [24   ] , Culture=neutral, PublicKeyToken=null]] - Stop background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 14:31:57,630 [24   ] Abp.BackgroundJobs.BackgroundJobManager  - WaitToStop background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 14:31:57,631 [24   ] , Culture=neutral, PublicKeyToken=null]] - WaitToStop background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 14:31:57,631 [24   ] Abp.Modules.AbpModuleManager             - Shutting down completed.
+INFO  2026-04-02 14:31:57,634 [24   ] Microsoft.Hosting.Lifetime               - Application is shutting down...
+DEBUG 2026-04-02 14:49:03,313 [2    ] Abp.Modules.AbpModuleManager             - Loading Abp modules...
+DEBUG 2026-04-02 14:49:03,325 [2    ] Abp.Modules.AbpModuleManager             - Found 15 ABP modules in total.
+DEBUG 2026-04-02 14:49:03,338 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.Web.Host.Startup.backendWebHostModule, backend.Web.Host, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,339 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendWebCoreModule, backend.Web.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,339 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendApplicationModule, backend.Application, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,340 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendCoreModule, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,340 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.AbpZeroCoreModule, Abp.ZeroCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,340 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.AbpZeroCommonModule, Abp.Zero.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,340 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AbpKernelModule, Abp, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,341 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AutoMapper.AbpAutoMapperModule, Abp.AutoMapper, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,341 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.EntityFrameworkCore.backendEntityFrameworkModule, backend.EntityFrameworkCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,341 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.EntityFrameworkCore.AbpZeroCoreEntityFrameworkCoreModule, Abp.ZeroCore.EntityFrameworkCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,341 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.EntityFrameworkCore.AbpEntityFrameworkCoreModule, Abp.EntityFrameworkCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,342 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.EntityFramework.AbpEntityFrameworkCommonModule, Abp.EntityFramework.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,342 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AspNetCore.AbpAspNetCoreModule, Abp.AspNetCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,342 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Web.AbpWebCommonModule, Abp.Web.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,342 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AspNetCore.SignalR.AbpAspNetCoreSignalRModule, Abp.AspNetCore.SignalR, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,343 [2    ] Abp.Modules.AbpModuleManager             - 15 modules loaded.
+DEBUG 2026-04-02 14:49:03,400 [2    ] o.Configuration.LanguageManagementConfig - Converted Abp (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 14:49:03,401 [2    ] o.Configuration.LanguageManagementConfig - Converted AbpZero (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 14:49:03,401 [2    ] o.Configuration.LanguageManagementConfig - Converted backend (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 14:49:03,401 [2    ] o.Configuration.LanguageManagementConfig - Converted AbpWeb (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 14:49:03,656 [2    ] ameworkCore.AbpEntityFrameworkCoreModule - Registering DbContext: backend.EntityFrameworkCore.backendDbContext, backend.EntityFrameworkCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:49:03,869 [2    ] Abp.Localization.LocalizationManager     - Initializing 4 localization sources.
+DEBUG 2026-04-02 14:49:03,903 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: Abp
+DEBUG 2026-04-02 14:49:03,916 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: AbpZero
+DEBUG 2026-04-02 14:49:03,925 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: backend
+DEBUG 2026-04-02 14:49:03,930 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: AbpWeb
+DEBUG 2026-04-02 14:49:03,938 [2    ] Abp.BackgroundJobs.BackgroundJobManager  - Start background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 14:49:03,941 [2    ] , Culture=neutral, PublicKeyToken=null]] - Start background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 14:49:03,957 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - Found 10 classes define auto mapping attributes
+DEBUG 2026-04-02 14:49:03,957 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Users.Dto.CreateUserDto
+DEBUG 2026-04-02 14:49:03,966 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Users.Dto.UserDto
+DEBUG 2026-04-02 14:49:03,967 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Sessions.Dto.TenantLoginInfoDto
+DEBUG 2026-04-02 14:49:03,967 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Sessions.Dto.UserLoginInfoDto
+DEBUG 2026-04-02 14:49:03,967 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.LegalDocumentService.DTO.LegalDocumentDto
+DEBUG 2026-04-02 14:49:03,968 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.LegalDocumentService.DTO.LegalDocumentListDto
+DEBUG 2026-04-02 14:49:03,968 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.CategoryService.DTO.CategoryDto
+DEBUG 2026-04-02 14:49:03,968 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Roles.Dto.PermissionDto
+DEBUG 2026-04-02 14:49:03,968 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.MultiTenancy.Dto.CreateTenantDto
+DEBUG 2026-04-02 14:49:03,968 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.MultiTenancy.Dto.TenantDto
+INFO  2026-04-02 14:49:23,302 [2    ] tCore.Builder.RequestLocalizationOptions - Supported Request Localization Cultures: en,es-MX,fr,de,it,nl,pt-BR,tr,ru,ar,fa,ja,zh-Hans
+INFO  2026-04-02 14:49:23,518 [2    ] Microsoft.Hosting.Lifetime               - Now listening on: https://localhost:44311
+INFO  2026-04-02 14:49:23,518 [2    ] Microsoft.Hosting.Lifetime               - Now listening on: http://localhost:21021
+INFO  2026-04-02 14:49:23,553 [2    ] Microsoft.Hosting.Lifetime               - Application started. Press Ctrl+C to shut down.
+INFO  2026-04-02 14:49:23,553 [2    ] Microsoft.Hosting.Lifetime               - Hosting environment: Development
+INFO  2026-04-02 14:49:23,553 [2    ] Microsoft.Hosting.Lifetime               - Content root path: C:\Users\Nhlakanipho\Documents\Projects\Mzansi-legal\backend\src\backend.Web.Host
+INFO  2026-04-02 14:49:24,325 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/ - - -
+INFO  2026-04-02 14:49:24,599 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host)'
+INFO  2026-04-02 14:49:24,651 [8    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "Index", controller = "Home", area = ""}. Executing controller action with signature Microsoft.AspNetCore.Mvc.IActionResult Index() on controller backend.Web.Host.Controllers.HomeController (backend.Web.Host).
+INFO  2026-04-02 14:49:26,609 [15   ] vc.Infrastructure.RedirectResultExecutor - Executing RedirectResult, redirecting to /swagger.
+INFO  2026-04-02 14:49:26,650 [15   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host) in 1959.8614ms
+INFO  2026-04-02 14:49:26,651 [15   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host)'
+INFO  2026-04-02 14:49:26,692 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/ - 302 - - 2352.8792ms
+INFO  2026-04-02 14:49:26,857 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/_framework/aspnetcore-browser-refresh.js - - -
+INFO  2026-04-02 14:49:26,872 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/_vs/browserLink - - -
+INFO  2026-04-02 14:49:26,929 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/_framework/aspnetcore-browser-refresh.js - 200 14937 application/javascript;+charset=utf-8 64.5981ms
+INFO  2026-04-02 14:49:27,061 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/_vs/browserLink - 200 - text/javascript;+charset=UTF-8 180.1275ms
+INFO  2026-04-02 14:49:27,084 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/AntiForgery/SetCookie - - -
+INFO  2026-04-02 14:49:27,101 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host)'
+INFO  2026-04-02 14:49:27,130 [15   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/swagger/v1/swagger.json - - -
+INFO  2026-04-02 14:49:27,167 [8    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "SetCookie", controller = "AntiForgery", area = ""}. Executing controller action with signature Void SetCookie() on controller backend.Web.Host.Controllers.AntiForgeryController (backend.Web.Host).
+INFO  2026-04-02 14:49:27,738 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/swagger/v1/swagger.json - 200 - application/json;charset=utf-8 607.3486ms
+INFO  2026-04-02 14:49:28,784 [8    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:49:28,834 [8    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host) in 1666.5157ms
+INFO  2026-04-02 14:49:28,834 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host)'
+INFO  2026-04-02 14:49:28,835 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/AntiForgery/SetCookie - 200 - application/json;+charset=utf-8 1750.7339ms
+INFO  2026-04-02 14:49:50,098 [16   ] ckend.Web.Host.Startup.RagStartupService - [RagService] Chunk embeddings loaded into memory. RAG service is ready.
+DEBUG 2026-04-02 14:57:32,755 [3    ] Abp.Modules.AbpModuleManager             - Shutting down has been started
+DEBUG 2026-04-02 14:57:32,763 [3    ] Abp.BackgroundJobs.BackgroundJobManager  - Stop background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 14:57:32,764 [3    ] , Culture=neutral, PublicKeyToken=null]] - Stop background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 14:57:32,766 [3    ] Abp.BackgroundJobs.BackgroundJobManager  - WaitToStop background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 14:57:32,766 [3    ] , Culture=neutral, PublicKeyToken=null]] - WaitToStop background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 14:57:32,766 [3    ] Abp.Modules.AbpModuleManager             - Shutting down completed.
+INFO  2026-04-02 14:57:32,771 [3    ] Microsoft.Hosting.Lifetime               - Application is shutting down...
+DEBUG 2026-04-02 14:57:48,906 [2    ] Abp.Modules.AbpModuleManager             - Loading Abp modules...
+DEBUG 2026-04-02 14:57:48,916 [2    ] Abp.Modules.AbpModuleManager             - Found 15 ABP modules in total.
+DEBUG 2026-04-02 14:57:48,925 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.Web.Host.Startup.backendWebHostModule, backend.Web.Host, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,927 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendWebCoreModule, backend.Web.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,928 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendApplicationModule, backend.Application, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,928 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.backendCoreModule, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,928 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.AbpZeroCoreModule, Abp.ZeroCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,928 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.AbpZeroCommonModule, Abp.Zero.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,929 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AbpKernelModule, Abp, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,932 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AutoMapper.AbpAutoMapperModule, Abp.AutoMapper, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,933 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: backend.EntityFrameworkCore.backendEntityFrameworkModule, backend.EntityFrameworkCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,933 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Zero.EntityFrameworkCore.AbpZeroCoreEntityFrameworkCoreModule, Abp.ZeroCore.EntityFrameworkCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,934 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.EntityFrameworkCore.AbpEntityFrameworkCoreModule, Abp.EntityFrameworkCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,934 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.EntityFramework.AbpEntityFrameworkCommonModule, Abp.EntityFramework.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,934 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AspNetCore.AbpAspNetCoreModule, Abp.AspNetCore, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,934 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.Web.AbpWebCommonModule, Abp.Web.Common, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,934 [2    ] Abp.Modules.AbpModuleManager             - Loaded module: Abp.AspNetCore.SignalR.AbpAspNetCoreSignalRModule, Abp.AspNetCore.SignalR, Version=10.2.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:48,936 [2    ] Abp.Modules.AbpModuleManager             - 15 modules loaded.
+DEBUG 2026-04-02 14:57:48,976 [2    ] o.Configuration.LanguageManagementConfig - Converted Abp (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 14:57:48,976 [2    ] o.Configuration.LanguageManagementConfig - Converted AbpZero (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 14:57:48,976 [2    ] o.Configuration.LanguageManagementConfig - Converted backend (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 14:57:48,976 [2    ] o.Configuration.LanguageManagementConfig - Converted AbpWeb (Abp.Localization.Dictionaries.DictionaryBasedLocalizationSource) to MultiTenantLocalizationSource
+DEBUG 2026-04-02 14:57:49,193 [2    ] ameworkCore.AbpEntityFrameworkCoreModule - Registering DbContext: backend.EntityFrameworkCore.backendDbContext, backend.EntityFrameworkCore, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+DEBUG 2026-04-02 14:57:49,372 [2    ] Abp.Localization.LocalizationManager     - Initializing 4 localization sources.
+DEBUG 2026-04-02 14:57:49,402 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: Abp
+DEBUG 2026-04-02 14:57:49,411 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: AbpZero
+DEBUG 2026-04-02 14:57:49,417 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: backend
+DEBUG 2026-04-02 14:57:49,420 [2    ] Abp.Localization.LocalizationManager     - Initialized localization source: AbpWeb
+DEBUG 2026-04-02 14:57:49,426 [2    ] Abp.BackgroundJobs.BackgroundJobManager  - Start background worker: Abp.BackgroundJobs.BackgroundJobManager
+DEBUG 2026-04-02 14:57:49,429 [2    ] , Culture=neutral, PublicKeyToken=null]] - Start background worker: Abp.Authorization.Users.UserTokenExpirationWorker`2[[backend.MultiTenancy.Tenant, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null],[backend.Authorization.Users.User, backend.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
+DEBUG 2026-04-02 14:57:49,442 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - Found 10 classes define auto mapping attributes
+DEBUG 2026-04-02 14:57:49,442 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Users.Dto.CreateUserDto
+DEBUG 2026-04-02 14:57:49,444 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Users.Dto.UserDto
+DEBUG 2026-04-02 14:57:49,445 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Sessions.Dto.TenantLoginInfoDto
+DEBUG 2026-04-02 14:57:49,445 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Sessions.Dto.UserLoginInfoDto
+DEBUG 2026-04-02 14:57:49,445 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.LegalDocumentService.DTO.LegalDocumentDto
+DEBUG 2026-04-02 14:57:49,445 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.LegalDocumentService.DTO.LegalDocumentListDto
+DEBUG 2026-04-02 14:57:49,445 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Services.CategoryService.DTO.CategoryDto
+DEBUG 2026-04-02 14:57:49,445 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.Roles.Dto.PermissionDto
+DEBUG 2026-04-02 14:57:49,445 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.MultiTenancy.Dto.CreateTenantDto
+DEBUG 2026-04-02 14:57:49,445 [2    ] Abp.AutoMapper.AbpAutoMapperModule       - backend.MultiTenancy.Dto.TenantDto
+INFO  2026-04-02 14:58:13,384 [2    ] tCore.Builder.RequestLocalizationOptions - Supported Request Localization Cultures: en,es-MX,fr,de,it,nl,pt-BR,tr,ru,ar,fa,ja,zh-Hans
+INFO  2026-04-02 14:58:13,598 [2    ] Microsoft.Hosting.Lifetime               - Now listening on: https://localhost:44311
+INFO  2026-04-02 14:58:13,598 [2    ] Microsoft.Hosting.Lifetime               - Now listening on: http://localhost:21021
+INFO  2026-04-02 14:58:13,630 [2    ] Microsoft.Hosting.Lifetime               - Application started. Press Ctrl+C to shut down.
+INFO  2026-04-02 14:58:13,630 [2    ] Microsoft.Hosting.Lifetime               - Hosting environment: Development
+INFO  2026-04-02 14:58:13,630 [2    ] Microsoft.Hosting.Lifetime               - Content root path: C:\Users\Nhlakanipho\Documents\Projects\Mzansi-legal\backend\src\backend.Web.Host
+INFO  2026-04-02 14:58:13,934 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/ - - -
+INFO  2026-04-02 14:58:14,084 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host)'
+INFO  2026-04-02 14:58:14,103 [9    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "Index", controller = "Home", area = ""}. Executing controller action with signature Microsoft.AspNetCore.Mvc.IActionResult Index() on controller backend.Web.Host.Controllers.HomeController (backend.Web.Host).
+INFO  2026-04-02 14:58:17,772 [9    ] vc.Infrastructure.RedirectResultExecutor - Executing RedirectResult, redirecting to /swagger.
+INFO  2026-04-02 14:58:17,788 [9    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host) in 3670.5656ms
+INFO  2026-04-02 14:58:17,788 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.HomeController.Index (backend.Web.Host)'
+INFO  2026-04-02 14:58:17,797 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/ - 302 - - 3862.3421ms
+INFO  2026-04-02 14:58:17,905 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/_framework/aspnetcore-browser-refresh.js - - -
+INFO  2026-04-02 14:58:17,912 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/_framework/aspnetcore-browser-refresh.js - 200 14937 application/javascript;+charset=utf-8 6.4916ms
+INFO  2026-04-02 14:58:17,923 [16   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/_vs/browserLink - - -
+INFO  2026-04-02 14:58:17,944 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/_vs/browserLink - 200 - text/javascript;+charset=UTF-8 21.7547ms
+INFO  2026-04-02 14:58:18,484 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/AntiForgery/SetCookie - - -
+INFO  2026-04-02 14:58:18,484 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/2 GET https://localhost:44311/swagger/v1/swagger.json - - -
+INFO  2026-04-02 14:58:18,486 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host)'
+INFO  2026-04-02 14:58:18,495 [8    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "SetCookie", controller = "AntiForgery", area = ""}. Executing controller action with signature Void SetCookie() on controller backend.Web.Host.Controllers.AntiForgeryController (backend.Web.Host).
+INFO  2026-04-02 14:58:18,544 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/swagger/v1/swagger.json - 200 - application/json;charset=utf-8 59.2989ms
+INFO  2026-04-02 14:58:20,140 [8    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:58:20,146 [8    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host) in 1650.8549ms
+INFO  2026-04-02 14:58:20,146 [8    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.AntiForgeryController.SetCookie (backend.Web.Host)'
+INFO  2026-04-02 14:58:20,146 [8    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/2 GET https://localhost:44311/AntiForgery/SetCookie - 200 - application/json;+charset=utf-8 1662.5079ms
+INFO  2026-04-02 14:58:51,588 [6    ] ckend.Web.Host.Startup.RagStartupService - [RagService] Chunk embeddings loaded into memory. RAG service is ready.
+INFO  2026-04-02 14:59:20,098 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 14:59:20,100 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 14:59:20,102 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:59:20,102 [10   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:59:20,106 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - 204 - - 6.5709ms
+INFO  2026-04-02 14:59:20,112 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - 204 - - 14.1681ms
+INFO  2026-04-02 14:59:20,117 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 14:59:20,118 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:59:21,652 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 14:59:21,667 [9    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetMy", controller = "Contract", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.ContractService.DTO.ContractAnalysisListDto] GetMy() on controller backend.Web.Host.Controllers.ContractController (backend.Web.Host).
+INFO  2026-04-02 14:59:25,049 [10   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:59:25,077 [10   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host) in 3410.3177ms
+INFO  2026-04-02 14:59:25,078 [10   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 14:59:25,079 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/contract/my - 200 - application/json;+charset=utf-8 4961.8211ms
+INFO  2026-04-02 14:59:25,085 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 14:59:25,086 [6    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:59:25,093 [6    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 14:59:25,100 [6    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetMy", controller = "Contract", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.ContractService.DTO.ContractAnalysisListDto] GetMy() on controller backend.Web.Host.Controllers.ContractController (backend.Web.Host).
+INFO  2026-04-02 14:59:28,306 [6    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:59:28,307 [6    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host) in 3207.1232ms
+INFO  2026-04-02 14:59:28,307 [6    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 14:59:28,307 [6    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/contract/my - 200 - application/json;+charset=utf-8 3221.9957ms
+INFO  2026-04-02 14:59:30,596 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 14:59:30,598 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:59:30,598 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - 204 - - 2.3761ms
+INFO  2026-04-02 14:59:30,598 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 14:59:30,598 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:59:30,599 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/contract/my - 204 - - 0.3134ms
+INFO  2026-04-02 14:59:30,604 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 14:59:30,604 [10   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:59:30,605 [10   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 14:59:30,612 [10   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetMy", controller = "Contract", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.ContractService.DTO.ContractAnalysisListDto] GetMy() on controller backend.Web.Host.Controllers.ContractController (backend.Web.Host).
+INFO  2026-04-02 14:59:33,812 [9    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:59:33,813 [9    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host) in 3200.1925ms
+INFO  2026-04-02 14:59:33,813 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 14:59:33,813 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/contract/my - 200 - application/json;+charset=utf-8 3209.3582ms
+INFO  2026-04-02 14:59:33,824 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/contract/my - - -
+INFO  2026-04-02 14:59:33,824 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 14:59:33,825 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 14:59:33,847 [9    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetMy", controller = "Contract", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.ContractService.DTO.ContractAnalysisListDto] GetMy() on controller backend.Web.Host.Controllers.ContractController (backend.Web.Host).
+INFO  2026-04-02 14:59:37,048 [9    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 14:59:37,049 [9    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host) in 3201.736ms
+INFO  2026-04-02 14:59:37,049 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.ContractController.GetMy (backend.Web.Host)'
+INFO  2026-04-02 14:59:37,049 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/contract/my - 200 - application/json;+charset=utf-8 3225.2114ms
+INFO  2026-04-02 15:00:24,622 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/qa/conversations - - -
+INFO  2026-04-02 15:00:24,623 [10   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 15:00:24,623 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/qa/conversations - 204 - - 0.6098ms
+INFO  2026-04-02 15:00:24,628 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 GET http://localhost:21021/api/app/qa/conversations - application/json -
+INFO  2026-04-02 15:00:24,628 [10   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 15:00:24,629 [10   ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QaController.GetConversations (backend.Web.Host)'
+INFO  2026-04-02 15:00:24,663 [10   ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "GetConversations", controller = "Qa", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RagService.DTO.ConversationsListDto] GetConversations() on controller backend.Web.Host.Controllers.QaController (backend.Web.Host).
+INFO  2026-04-02 15:00:27,890 [9    ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 15:00:27,896 [9    ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QaController.GetConversations (backend.Web.Host) in 3233.1156ms
+INFO  2026-04-02 15:00:27,896 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QaController.GetConversations (backend.Web.Host)'
+INFO  2026-04-02 15:00:27,898 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 GET http://localhost:21021/api/app/qa/conversations - 200 - application/json;+charset=utf-8 3269.8028ms
+INFO  2026-04-02 15:00:46,043 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 OPTIONS http://localhost:21021/api/app/qa/ask - - -
+INFO  2026-04-02 15:00:46,043 [10   ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 15:00:46,044 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 OPTIONS http://localhost:21021/api/app/qa/ask - 204 - - 0.5266ms
+INFO  2026-04-02 15:00:46,049 [9    ] Microsoft.AspNetCore.Hosting.Diagnostics - Request starting HTTP/1.1 POST http://localhost:21021/api/app/qa/ask - application/json 36
+INFO  2026-04-02 15:00:46,049 [9    ] pNetCore.Cors.Infrastructure.CorsService - CORS policy execution successful.
+INFO  2026-04-02 15:00:46,062 [9    ] ft.AspNetCore.Routing.EndpointMiddleware - Executing endpoint 'backend.Web.Host.Controllers.QaController.Ask (backend.Web.Host)'
+INFO  2026-04-02 15:00:46,091 [9    ] c.Infrastructure.ControllerActionInvoker - Route matched with {action = "Ask", controller = "Qa", area = ""}. Executing controller action with signature System.Threading.Tasks.Task`1[backend.Services.RagService.DTO.RagAnswerResult] Ask(backend.Services.RagService.DTO.AskQuestionRequest) on controller backend.Web.Host.Controllers.QaController (backend.Web.Host).
+INFO  2026-04-02 15:00:46,355 [9    ] et.Http.HttpClient.OpenAI.LogicalHandler - Start processing HTTP request POST https://api.openai.com/v1/chat/completions
+INFO  2026-04-02 15:00:46,355 [9    ] Net.Http.HttpClient.OpenAI.ClientHandler - Sending HTTP request POST https://api.openai.com/v1/chat/completions
+INFO  2026-04-02 15:00:48,571 [9    ] Net.Http.HttpClient.OpenAI.ClientHandler - Received HTTP response headers after 2208.2794ms - 200
+INFO  2026-04-02 15:00:48,572 [9    ] et.Http.HttpClient.OpenAI.LogicalHandler - End processing HTTP request after 2220.7822ms - 200
+INFO  2026-04-02 15:00:48,585 [9    ] et.Http.HttpClient.OpenAI.LogicalHandler - Start processing HTTP request POST https://api.openai.com/v1/embeddings
+INFO  2026-04-02 15:00:48,585 [9    ] Net.Http.HttpClient.OpenAI.ClientHandler - Sending HTTP request POST https://api.openai.com/v1/embeddings
+INFO  2026-04-02 15:00:52,006 [9    ] Net.Http.HttpClient.OpenAI.ClientHandler - Received HTTP response headers after 3421.2777ms - 200
+INFO  2026-04-02 15:00:52,006 [9    ] et.Http.HttpClient.OpenAI.LogicalHandler - End processing HTTP request after 3421.6034ms - 200
+INFO  2026-04-02 15:00:52,094 [9    ] et.Http.HttpClient.OpenAI.LogicalHandler - Start processing HTTP request POST https://api.openai.com/v1/embeddings
+INFO  2026-04-02 15:00:52,094 [9    ] Net.Http.HttpClient.OpenAI.ClientHandler - Sending HTTP request POST https://api.openai.com/v1/embeddings
+INFO  2026-04-02 15:00:54,282 [18   ] Net.Http.HttpClient.OpenAI.ClientHandler - Received HTTP response headers after 2187.6651ms - 200
+INFO  2026-04-02 15:00:54,282 [18   ] et.Http.HttpClient.OpenAI.LogicalHandler - End processing HTTP request after 2187.994ms - 200
+INFO  2026-04-02 15:00:55,230 [18   ] et.Http.HttpClient.OpenAI.LogicalHandler - Start processing HTTP request POST https://api.openai.com/v1/chat/completions
+INFO  2026-04-02 15:00:55,231 [18   ] Net.Http.HttpClient.OpenAI.ClientHandler - Sending HTTP request POST https://api.openai.com/v1/chat/completions
+INFO  2026-04-02 15:01:07,395 [10   ] Net.Http.HttpClient.OpenAI.ClientHandler - Received HTTP response headers after 12164.0018ms - 200
+INFO  2026-04-02 15:01:07,395 [10   ] et.Http.HttpClient.OpenAI.LogicalHandler - End processing HTTP request after 12164.4642ms - 200
+INFO  2026-04-02 15:01:10,439 [10   ] .Mvc.Infrastructure.ObjectResultExecutor - Executing ObjectResult, writing value of type 'Abp.Web.Models.AjaxResponse'.
+INFO  2026-04-02 15:01:10,471 [10   ] c.Infrastructure.ControllerActionInvoker - Executed action backend.Web.Host.Controllers.QaController.Ask (backend.Web.Host) in 24380.4212ms
+INFO  2026-04-02 15:01:10,471 [10   ] ft.AspNetCore.Routing.EndpointMiddleware - Executed endpoint 'backend.Web.Host.Controllers.QaController.Ask (backend.Web.Host)'
+INFO  2026-04-02 15:01:10,472 [10   ] Microsoft.AspNetCore.Hosting.Diagnostics - Request finished HTTP/1.1 POST http://localhost:21021/api/app/qa/ask - 200 - application/json;+charset=utf-8 24422.8195ms

--- a/backend/src/backend.Web.Host/Controllers/QaController.cs
+++ b/backend/src/backend.Web.Host/Controllers/QaController.cs
@@ -37,7 +37,8 @@ namespace backend.Web.Host.Controllers
 
         /// <summary>
         /// Returns the authenticated user's conversation history, newest first.
-        /// Each item includes the first question and total question count.
+        /// Each item includes the conversation ID that clients can send back on follow-up questions,
+        /// along with the first question and total question count.
         /// </summary>
         [HttpGet("conversations")]
         [AbpAuthorize]

--- a/backend/test/backend.Tests/RagServiceTests/RagAppServiceTests.cs
+++ b/backend/test/backend.Tests/RagServiceTests/RagAppServiceTests.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Linq.Expressions;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -27,17 +28,17 @@ namespace backend.Tests.RagServiceTests;
 public class RagAppServiceTests
 {
     [Fact]
-    public async Task AskAsync_AuthenticatedGroundedAnswer_PersistsQuestionAndAnswer()
+    public async Task AskAsync_AuthenticatedGroundedAnswer_AnswerAndCitationsArePersisted()
     {
-        var service = CreateService(
+        var harness = CreateHarness(
             CreateGroundedHousingChunks(),
             new float[] { 1f, 0f },
             Language.Zulu,
             "Can my landlord evict me without a court order?",
             "Cha. Umnikazi wendlu akakwazi ukukuxosha ngaphandle kwenqubo yasenkantolo [Constitution of the Republic of South Africa, Section 26(3)].");
-        service.UseSession(42);
+        harness.Service.UseSession(42);
 
-        var result = await service.AskAsync(new AskQuestionRequest
+        var result = await harness.Service.AskAsync(new AskQuestionRequest
         {
             QuestionText = "Ingabe umnikazi wendlu angangixosha?"
         });
@@ -46,32 +47,35 @@ public class RagAppServiceTests
         result.DetectedLanguageCode.ShouldBe("zu");
         result.AnswerMode.ShouldNotBe(RagAnswerMode.Clarification);
         result.AnswerMode.ShouldNotBe(RagAnswerMode.Insufficient);
-        result.AnswerId.ShouldBe(service.NextAnswerId);
+        result.AnswerId.ShouldBe(harness.Service.NextAnswerId);
+        result.AnswerId.ShouldNotBeNull();
         result.Citations.ShouldNotBeEmpty();
 
-        service.PersistedQuestionCount.ShouldBe(1);
-        service.PersistedAnswerCount.ShouldBe(1);
-        service.LastOriginalText.ShouldBe("Ingabe umnikazi wendlu angangixosha?");
-        service.LastTranslatedText.ShouldBe("Can my landlord evict me without a court order?");
-        service.LastQuestionLanguage.ShouldBe(Language.Zulu);
-        service.LastAnswerQuestionId.ShouldBe(service.NextQuestionId);
-        service.LastPersistedChunkIds.ShouldNotBeEmpty();
+        harness.Service.PersistedQuestionCount.ShouldBe(1);
+        harness.Service.PersistedAnswerCount.ShouldBe(1);
+        harness.Service.LastOriginalText.ShouldBe("Ingabe umnikazi wendlu angangixosha?");
+        harness.Service.LastTranslatedText.ShouldBe("Can my landlord evict me without a court order?");
+        harness.Service.LastQuestionLanguage.ShouldBe(Language.Zulu);
+        harness.Service.LastAnswerQuestionId.ShouldBe(harness.Service.NextQuestionId);
+        harness.Service.LastPersistedChunkIds.Count.ShouldBeGreaterThan(0);
     }
 
     [Fact]
     public async Task AskAsync_AuthenticatedInsufficientResponse_PersistsQuestionWithoutAnswer()
     {
-        var service = CreateService(
+        var harness = CreateHarness(
             CreateEmploymentChunks(),
             new float[] { 0f, 1f },
             Language.Afrikaans,
             "Can my landlord evict me without a court order?",
             "unused");
-        service.UseSession(42);
+        harness.Service.UseSession(42);
+        var suppliedConversationId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
-        var result = await service.AskAsync(new AskQuestionRequest
+        var result = await harness.Service.AskAsync(new AskQuestionRequest
         {
-            QuestionText = "Kan my verhuurder my uitsit?"
+            QuestionText = "Kan my verhuurder my uitsit?",
+            ConversationId = suppliedConversationId
         });
 
         result.AnswerMode.ShouldBe(RagAnswerMode.Insufficient);
@@ -80,11 +84,181 @@ public class RagAppServiceTests
         result.ChunkIds.ShouldBeEmpty();
         result.DetectedLanguageCode.ShouldBe("af");
 
-        service.PersistedQuestionCount.ShouldBe(1);
-        service.PersistedAnswerCount.ShouldBe(0);
-        service.LastOriginalText.ShouldBe("Kan my verhuurder my uitsit?");
-        service.LastTranslatedText.ShouldBe("Can my landlord evict me without a court order?");
-        service.LastQuestionLanguage.ShouldBe(Language.Afrikaans);
+        harness.Service.PersistedQuestionCount.ShouldBe(1);
+        harness.Service.PersistedAnswerCount.ShouldBe(0);
+        harness.Service.LastConversationId.ShouldBe(suppliedConversationId);
+        harness.Service.LastOriginalText.ShouldBe("Kan my verhuurder my uitsit?");
+        harness.Service.LastTranslatedText.ShouldBe("Can my landlord evict me without a court order?");
+        harness.Service.LastQuestionLanguage.ShouldBe(Language.Afrikaans);
+    }
+
+    [Fact]
+    public async Task AskAsync_AnonymousUser_NoPersistenceOccurs()
+    {
+        var harness = CreateHarness(
+            CreateGroundedHousingChunks(),
+            new float[] { 1f, 0f },
+            Language.English,
+            "Can my landlord evict me without a court order?",
+            "No. A landlord cannot evict you without a court order.");
+        harness.Service.UseSession(null);
+
+        var result = await harness.Service.AskAsync(new AskQuestionRequest
+        {
+            QuestionText = "Can my landlord evict me without a court order?"
+        });
+
+        result.AnswerId.ShouldBeNull();
+        harness.Service.PersistedQuestionCount.ShouldBe(0);
+        harness.Service.PersistedAnswerCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task AskAsync_WithValidConversationId_ReusesThatConversation()
+    {
+        var harness = CreateHarness(
+            CreateGroundedHousingChunks(),
+            new float[] { 1f, 0f },
+            Language.English,
+            "Can my landlord evict me without a court order?",
+            "No. A landlord cannot evict you without a court order.");
+        var suppliedConversationId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        harness.SeedConversation(
+            suppliedConversationId,
+            42,
+            DateTime.UtcNow.AddMinutes(-10),
+            "Can my landlord evict me without a court order?");
+        harness.Service.UseSession(42);
+        harness.Service.UseBaseQuestionPersistence = true;
+
+        var result = await harness.Service.AskAsync(new AskQuestionRequest
+        {
+            QuestionText = "What if they change the locks?",
+            ConversationId = suppliedConversationId
+        });
+
+        harness.Service.LastConversationId.ShouldBe(suppliedConversationId);
+        harness.Conversations.Count.ShouldBe(1);
+        harness.Questions.Count.ShouldBe(1);
+        harness.Questions[0].ConversationId.ShouldBe(suppliedConversationId);
+        result.ConversationId.ShouldBe(suppliedConversationId);
+    }
+
+    [Fact]
+    public async Task AskAsync_WithConversationIdBelongingToAnotherUser_CreatesNewConversation()
+    {
+        var harness = CreateHarness(
+            CreateGroundedHousingChunks(),
+            new float[] { 1f, 0f },
+            Language.English,
+            "Can my landlord evict me without a court order?",
+            "No. A landlord cannot evict you without a court order.");
+        var foreignConversationId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+        harness.SeedConversation(
+            foreignConversationId,
+            7,
+            DateTime.UtcNow.AddMinutes(-5),
+            "Can my landlord evict me without a court order?");
+        harness.Service.UseSession(42);
+        harness.Service.UseBaseQuestionPersistence = true;
+
+        var result = await harness.Service.AskAsync(new AskQuestionRequest
+        {
+            QuestionText = "What if they disconnect the water?",
+            ConversationId = foreignConversationId
+        });
+
+        harness.Conversations.Count.ShouldBe(2);
+        harness.Questions.Count.ShouldBe(1);
+        harness.Questions[0].ConversationId.ShouldBe(harness.NextConversationId);
+        result.ConversationId.ShouldBe(harness.NextConversationId);
+        result.ConversationId.ShouldNotBe(foreignConversationId);
+    }
+
+    [Fact]
+    public async Task AskAsync_WithNullConversationId_CreatesNewConversation()
+    {
+        var harness = CreateHarness(
+            CreateGroundedHousingChunks(),
+            new float[] { 1f, 0f },
+            Language.English,
+            "Can my landlord evict me without a court order?",
+            "No. A landlord cannot evict you without a court order.");
+        harness.Service.UseSession(42);
+        harness.Service.UseBaseQuestionPersistence = true;
+
+        var result = await harness.Service.AskAsync(new AskQuestionRequest
+        {
+            QuestionText = "What if my landlord threatens me?"
+        });
+
+        harness.Service.LastConversationId.ShouldBeNull();
+        harness.Conversations.Count.ShouldBe(1);
+        harness.Questions.Count.ShouldBe(1);
+        harness.Questions[0].ConversationId.ShouldBe(harness.NextConversationId);
+        result.ConversationId.ShouldBe(harness.NextConversationId);
+    }
+
+    [Fact]
+    public async Task GetConversationsAsync_ReturnsOnlyCurrentUserConversations_OrderedByStartedAtDescending()
+    {
+        var harness = CreateHarness(
+            CreateGroundedHousingChunks(),
+            new float[] { 1f, 0f },
+            Language.English,
+            "Can my landlord evict me without a court order?",
+            "unused");
+        harness.Service.UseSession(42);
+        harness.SeedConversation(
+            Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+            42,
+            DateTime.UtcNow.AddHours(-2),
+            "Older question");
+        harness.SeedConversation(
+            Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+            7,
+            DateTime.UtcNow.AddHours(-1),
+            "Other user's question");
+        harness.SeedConversation(
+            Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+            42,
+            DateTime.UtcNow,
+            "Newest question");
+
+        var result = await harness.Service.GetConversationsAsync();
+
+        result.TotalCount.ShouldBe(2);
+        result.Items.Select(item => item.ConversationId).ShouldBe(new[]
+        {
+            Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+            Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+        });
+    }
+
+    [Fact]
+    public async Task GetConversationsAsync_IncludesFirstQuestionAndCount()
+    {
+        var harness = CreateHarness(
+            CreateGroundedHousingChunks(),
+            new float[] { 1f, 0f },
+            Language.English,
+            "Can my landlord evict me without a court order?",
+            "unused");
+        harness.Service.UseSession(42);
+        var conversation = harness.SeedConversation(
+            Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd"),
+            42,
+            DateTime.UtcNow,
+            "First question",
+            "Second question");
+
+        var result = await harness.Service.GetConversationsAsync();
+
+        result.TotalCount.ShouldBe(1);
+        result.Items[0].ConversationId.ShouldBe(conversation.Id);
+        result.Items[0].FirstQuestion.ShouldBe("First question");
+        result.Items[0].QuestionCount.ShouldBe(2);
+        result.Items[0].Language.ShouldBe("english");
     }
 
     [Fact]
@@ -208,7 +382,7 @@ public class RagAppServiceTests
             citation.SourceRole == RagSourceMetadata.Supporting);
     }
 
-    private static TestableRagAppService CreateService(
+    private static RagAppServiceHarness CreateHarness(
         IReadOnlyList<IndexedChunk> loadedChunks,
         float[] questionVector,
         Language detectedLanguage,
@@ -236,14 +410,9 @@ public class RagAppServiceTests
             BaseAddress = new Uri("https://api.openai.com/")
         });
 
-        return new TestableRagAppService(
+        return new RagAppServiceHarness(
             embeddingService,
             languageService,
-            Substitute.For<IRepository<DocumentChunk, Guid>>(),
-            Substitute.For<IRepository<Conversation, Guid>>(),
-            Substitute.For<IRepository<Question, Guid>>(),
-            Substitute.For<IRepository<Answer, Guid>>(),
-            Substitute.For<IRepository<AnswerCitation, Guid>>(),
             store,
             httpFactory,
             BuildConfig());
@@ -378,6 +547,123 @@ public class RagAppServiceTests
         }
     }
 
+    private sealed class RagAppServiceHarness
+    {
+        public Guid NextConversationId { get; } = Guid.Parse("33333333-3333-3333-3333-333333333333");
+        public Guid NextQuestionId { get; } = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        public Guid NextAnswerId { get; } = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        public List<Conversation> Conversations { get; } = new();
+        public List<Question> Questions { get; } = new();
+        public List<Answer> Answers { get; } = new();
+        public List<AnswerCitation> Citations { get; } = new();
+        public TestableRagAppService Service { get; }
+
+        public RagAppServiceHarness(
+            IEmbeddingAppService embeddingService,
+            ILanguageAppService languageService,
+            RagIndexStore ragIndexStore,
+            IHttpClientFactory httpClientFactory,
+            IConfiguration configuration)
+        {
+            var conversationRepository = Substitute.For<IRepository<Conversation, Guid>>();
+            var questionRepository = Substitute.For<IRepository<Question, Guid>>();
+            var answerRepository = Substitute.For<IRepository<Answer, Guid>>();
+            var citationRepository = Substitute.For<IRepository<AnswerCitation, Guid>>();
+
+            conversationRepository.GetAll().Returns(_ => Conversations.AsQueryable());
+            conversationRepository.FirstOrDefaultAsync(Arg.Any<Expression<Func<Conversation, bool>>>())
+                .Returns(call =>
+                {
+                    var predicate = call.Arg<Expression<Func<Conversation, bool>>>().Compile();
+                    return Task.FromResult(Conversations.FirstOrDefault(predicate) ?? null!);
+                });
+            conversationRepository.InsertAndGetIdAsync(Arg.Any<Conversation>())
+                .Returns(call =>
+                {
+                    var entity = call.Arg<Conversation>();
+                    entity.Id = NextConversationId;
+                    entity.Questions ??= new List<Question>();
+                    Conversations.Add(entity);
+                    return Task.FromResult(entity.Id);
+                });
+
+            questionRepository.InsertAndGetIdAsync(Arg.Any<Question>())
+                .Returns(call =>
+                {
+                    var entity = call.Arg<Question>();
+                    entity.Id = NextQuestionId;
+                    Questions.Add(entity);
+
+                    var conversation = Conversations.FirstOrDefault(item => item.Id == entity.ConversationId);
+                    if (conversation != null)
+                    {
+                        conversation.Questions ??= new List<Question>();
+                        conversation.Questions.Add(entity);
+                    }
+
+                    return Task.FromResult(entity.Id);
+                });
+
+            answerRepository.InsertAndGetIdAsync(Arg.Any<Answer>())
+                .Returns(call =>
+                {
+                    var entity = call.Arg<Answer>();
+                    entity.Id = NextAnswerId;
+                    Answers.Add(entity);
+                    return Task.FromResult(entity.Id);
+                });
+
+            citationRepository.InsertAsync(Arg.Any<AnswerCitation>())
+                .Returns(call =>
+                {
+                    var entity = call.Arg<AnswerCitation>();
+                    Citations.Add(entity);
+                    return Task.FromResult(entity);
+                });
+
+            Service = new TestableRagAppService(
+                embeddingService,
+                languageService,
+                Substitute.For<IRepository<DocumentChunk, Guid>>(),
+                conversationRepository,
+                questionRepository,
+                answerRepository,
+                citationRepository,
+                ragIndexStore,
+                httpClientFactory,
+                configuration);
+        }
+
+        public Conversation SeedConversation(
+            Guid conversationId,
+            long userId,
+            DateTime startedAt,
+            params string[] questionTexts)
+        {
+            var conversation = new Conversation
+            {
+                Id = conversationId,
+                UserId = userId,
+                Language = Language.English,
+                InputMethod = InputMethod.Text,
+                StartedAt = startedAt,
+                Questions = questionTexts.Select((text, index) => new Question
+                {
+                    Id = Guid.NewGuid(),
+                    ConversationId = conversationId,
+                    OriginalText = text,
+                    TranslatedText = text,
+                    Language = Language.English,
+                    InputMethod = InputMethod.Text,
+                    CreationTime = startedAt.AddMinutes(index)
+                }).ToList()
+            };
+
+            Conversations.Add(conversation);
+            return conversation;
+        }
+    }
+
     private sealed class TestableRagAppService : RagAppService
     {
         public TestableRagAppService(
@@ -407,8 +693,10 @@ public class RagAppServiceTests
 
         public Guid NextQuestionId { get; } = Guid.Parse("11111111-1111-1111-1111-111111111111");
         public Guid NextAnswerId { get; } = Guid.Parse("22222222-2222-2222-2222-222222222222");
+        public bool UseBaseQuestionPersistence { get; set; }
         public int PersistedQuestionCount { get; private set; }
         public int PersistedAnswerCount { get; private set; }
+        public Guid? LastConversationId { get; private set; }
         public string? LastOriginalText { get; private set; }
         public string? LastTranslatedText { get; private set; }
         public Language? LastQuestionLanguage { get; private set; }
@@ -422,17 +710,30 @@ public class RagAppServiceTests
             AbpSession = session;
         }
 
-        protected override Task<Guid> PersistQuestionAsync(
+        protected override async Task<PersistedQuestionResult> PersistQuestionAsync(
             long userId,
+            Guid? conversationId,
             string originalText,
             string translatedText,
             Language language)
         {
             PersistedQuestionCount++;
+            LastConversationId = conversationId;
             LastOriginalText = originalText;
             LastTranslatedText = translatedText;
             LastQuestionLanguage = language;
-            return Task.FromResult(NextQuestionId);
+
+            if (UseBaseQuestionPersistence)
+            {
+                return await base.PersistQuestionAsync(
+                    userId,
+                    conversationId,
+                    originalText,
+                    translatedText,
+                    language);
+            }
+
+            return new PersistedQuestionResult(NextQuestionId, conversationId ?? Guid.Parse("33333333-3333-3333-3333-333333333333"));
         }
 
         protected override Task<Guid> PersistAnswerAsync(
@@ -445,6 +746,11 @@ public class RagAppServiceTests
             LastAnswerQuestionId = questionId;
             LastPersistedChunkIds = usedChunks.Select(chunk => chunk.ChunkId).ToList();
             return Task.FromResult(NextAnswerId);
+        }
+
+        protected override Task<List<Conversation>> ListConversationsAsync(IOrderedQueryable<Conversation> query)
+        {
+            return Task.FromResult(query.ToList());
         }
     }
 }

--- a/frontend/src/app/[locale]/history/page.tsx
+++ b/frontend/src/app/[locale]/history/page.tsx
@@ -6,9 +6,8 @@ import Link from "next/link";
 import { appRoutes, createLocalizedPath } from "@/i18n/routing";
 import { C, R, fontSans, fontSerif, shadowOrganic } from "@/styles/theme";
 import AuthGuard from "@/components/guards/AuthGuard";
-import { HistoryProvider, useHistoryState, useHistoryAction } from "@/providers/history-provider";
+import { HistoryProvider, useHistoryState } from "@/providers/history-provider";
 import { Spin } from "antd";
-import { useEffect } from "react";
 
 const LOCALE_NAMES: Record<string, string> = {
   en: "English",
@@ -33,9 +32,6 @@ function HistoryContent() {
   const t = useTranslations("history");
   const locale = useLocale();
   const { items, isPending: isLoading, isError } = useHistoryState();
-  const { fetchAll } = useHistoryAction();
-
-  useEffect(() => { void fetchAll(); }, []);
 
   if (isLoading) {
     return (

--- a/frontend/src/providers/history-provider/index.tsx
+++ b/frontend/src/providers/history-provider/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useContext, useReducer } from "react";
+import { useContext, useEffect, useEffectEvent, useReducer } from "react";
 import { getConversations } from "@/services/qaService";
 import { useAuth } from "@/hooks/useAuth";
 import { HistoryReducer } from "./reducer";
@@ -7,7 +7,7 @@ import { INITIAL_STATE, HistoryStateContext, HistoryActionContext } from "./cont
 import { HistoryStateEnums } from "./actions";
 
 export const HistoryProvider = ({ children }: { children: React.ReactNode }) => {
-  const { user } = useAuth();
+  const { user, isLoading } = useAuth();
   const [state, dispatch] = useReducer(HistoryReducer, INITIAL_STATE);
 
   const fetchAll = async () => {
@@ -29,6 +29,17 @@ export const HistoryProvider = ({ children }: { children: React.ReactNode }) => 
       dispatch({ type: HistoryStateEnums.HISTORY_FETCH_ALL_ERROR });
     }
   };
+  const fetchAllOnReady = useEffectEvent(() => {
+    void fetchAll();
+  });
+
+  useEffect(() => {
+    if (isLoading || !user) {
+      return;
+    }
+
+    fetchAllOnReady();
+  }, [isLoading, user]);
 
   return (
     <HistoryStateContext.Provider value={state}>

--- a/frontend/src/services/qaService.ts
+++ b/frontend/src/services/qaService.ts
@@ -3,6 +3,58 @@ const API_BASE =
   process.env.NEXT_PUBLIC_BASE_URL ??
   "http://localhost:21021";
 const ABP_TENANT_HEADER = { "Abp-TenantId": "1" };
+const LOCAL_API_BASE_CANDIDATES = ["http://localhost:21021", "http://localhost:5000"];
+
+function getCookie(name: string): string | null {
+  if (typeof document === "undefined") return null;
+  const prefix = `${name}=`;
+  for (const part of document.cookie.split(";")) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith(prefix)) {
+      return decodeURIComponent(trimmed.slice(prefix.length));
+    }
+  }
+  return null;
+}
+
+function isLocalBrowserSession(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1";
+}
+
+function getApiBaseCandidates(): string[] {
+  if (!isLocalBrowserSession()) {
+    return [API_BASE];
+  }
+
+  const candidates = [...LOCAL_API_BASE_CANDIDATES];
+  if (!candidates.includes(API_BASE)) {
+    candidates.push(API_BASE);
+  }
+
+  return candidates;
+}
+
+async function fetchWithFallback(path: string, init: RequestInit): Promise<Response> {
+  let lastNetworkError: TypeError | null = null;
+
+  for (const apiBase of getApiBaseCandidates()) {
+    try {
+      return await fetch(`${apiBase}${path}`, init);
+    } catch (error) {
+      if (!(error instanceof TypeError)) {
+        throw error;
+      }
+
+      lastNetworkError = error;
+    }
+  }
+
+  throw lastNetworkError ?? new TypeError("Failed to fetch");
+}
 
 export interface CitationDto {
   actName: string;
@@ -87,22 +139,36 @@ export interface ConversationsListResponse {
 }
 
 export async function getConversations(token?: string): Promise<ConversationsListResponse> {
-  const res = await fetch(`${API_BASE}/api/app/qa/conversations`, {
+  const authToken = token ?? getCookie("ml_token");
+  const res = await fetchWithFallback("/api/app/qa/conversations", {
     method: "GET",
     headers: {
       "Content-Type": "application/json",
       ...ABP_TENANT_HEADER,
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
     },
   });
 
-  const json = await res.json();
+  const json = await res.json().catch(() => ({}));
 
   if (!res.ok) {
     throw new Error(json?.error?.message || "Failed to fetch conversations");
   }
 
-  return json.result as ConversationsListResponse;
+  const result = json.result as ConversationsListResponse;
+
+  return {
+    items: Array.isArray(result?.items)
+      ? result.items.map((item) => ({
+          conversationId: item.conversationId,
+          firstQuestion: item.firstQuestion,
+          questionCount: item.questionCount,
+          startedAt: item.startedAt,
+          locale: item.locale ?? (item as ConversationSummary & { language?: string }).language ?? "en",
+        }))
+      : [],
+    totalCount: result?.totalCount ?? 0,
+  };
 }
 
 export async function textToSpeech(

--- a/specs/feat/023-persist-qa-records/tasks.md
+++ b/specs/feat/023-persist-qa-records/tasks.md
@@ -1,0 +1,193 @@
+# Tasks: Persist Q&A Interaction Records (feat/023)
+
+**Branch**: `feat/023-persist-qa-records`
+**Input**: Design documents from `specs/feat/023-persist-qa-records/`
+**Prerequisites**: plan.md ✅ | spec.md ✅ | research.md ✅ | data-model.md ✅ | quickstart.md ✅
+
+**Tests**: Verification tasks cover every behavior change. No new entities or migrations needed.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the development environment is ready and all existing infrastructure is in place.
+No new project structure is required for this feature.
+
+- [ ] T001 Verify existing build passes: run `dotnet build backend/backend.sln` and confirm zero errors
+- [ ] T002 [P] Verify existing tests pass: run `dotnet test backend/backend.sln --filter "RagServiceTests"` and record baseline pass/fail count
+
+**Checkpoint**: Build is green, existing test suite passes — implementation can begin.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Update the `TestableRagAppService` spy infrastructure to track the new `conversationId`
+parameter before any story test or implementation work begins. All story verification tasks depend on this.
+
+- [X] T003 Update `TestableRagAppService.PersistQuestionAsync` override in `backend/test/backend.Tests/RagServiceTests/RagAppServiceTests.cs` to accept the new `Guid? conversationId` parameter and expose it as a `public Guid? LastConversationId { get; private set; }` property
+- [X] T004 Update `TestableRagAppService.PersistAnswerAsync` — no signature change needed; confirm it still compiles after T003
+
+**Checkpoint**: Test spy updated — all story verification tasks can now be written against `LastConversationId`.
+
+---
+
+## Phase 3: User Story 1 — Full Interaction Record Saved on Ask (Priority: P1) 🎯 MVP
+
+**Goal**: After any authenticated user asks a question, a complete chain of Conversation → Question → Answer → AnswerCitation records is written to the database with correct parent-child links.
+
+**Independent Test**: Call `POST /api/services/app/rag/ask` as an authenticated user, then inspect the database to confirm all four record types exist and are linked; or run the unit tests from T005–T006.
+
+### Verification — User Story 1 ⚠️
+
+- [X] T005 [P] [US1] Add unit test `AskAsync_AuthenticatedGroundedAnswer_AnswerAndCitationsArePersisted` in `backend/test/backend.Tests/RagServiceTests/RagAppServiceTests.cs` — asserts `PersistedQuestionCount == 1`, `PersistedAnswerCount == 1`, `LastPersistedChunkIds.Count > 0`, and `result.AnswerId != null`
+- [X] T006 [P] [US1] Add unit test `AskAsync_AnonymousUser_NoPersistenceOccurs` in `backend/test/backend.Tests/RagServiceTests/RagAppServiceTests.cs` — asserts `PersistedQuestionCount == 0` and `PersistedAnswerCount == 0` when `AbpSession.UserId` is null
+
+### Implementation — User Story 1
+
+- [X] T007 [US1] Add `Guid? ConversationId { get; set; }` property with XML doc comment to `backend/src/backend.Application/Services/RagService/DTO/AskQuestionRequest.cs`
+- [X] T008 [US1] Add `Guid? ConversationId { get; set; }` property with XML doc comment to `backend/src/backend.Application/Services/RagService/DTO/RagAnswerResult.cs` so the frontend can persist the ID for multi-turn use
+- [X] T009 [US1] Extract `CreateConversationAsync(long userId, Language language)` private helper method from the existing `PersistQuestionAsync` body in `backend/src/backend.Application/Services/RagService/RagAppService.cs`
+- [X] T010 [US1] Update `PersistQuestionAsync` signature in `backend/src/backend.Application/Services/RagService/RagAppService.cs` to accept `Guid? conversationId` as the second parameter (after `long userId`)
+- [X] T011 [US1] Add conversation-reuse logic inside the updated `PersistQuestionAsync`: look up existing `Conversation` by `conversationId && UserId`; fall back to `CreateConversationAsync` if not found or null — in `backend/src/backend.Application/Services/RagService/RagAppService.cs`
+- [X] T012 [US1] Update `PersistQuestionIfAuthenticatedAsync` to accept and thread through `Guid? conversationId` in `backend/src/backend.Application/Services/RagService/RagAppService.cs`
+- [X] T013 [US1] Update all three call sites of `PersistQuestionIfAuthenticatedAsync` / `PersistQuestionAsync` inside `AskAsync` to pass `request.ConversationId` in `backend/src/backend.Application/Services/RagService/RagAppService.cs`
+- [X] T014 [US1] Populate `result.ConversationId` in the grounded-answer return block of `AskAsync` (use the `conversationId` resolved inside `PersistQuestionAsync` — return it as part of the result) in `backend/src/backend.Application/Services/RagService/RagAppService.cs`
+- [ ] T015 [US1] Run `dotnet build backend/backend.sln` and fix any compilation errors introduced by the signature changes
+
+**Checkpoint**: All US1 tests (T005, T006) pass; existing tests still pass; a real grounded question persists all four record types end-to-end.
+
+---
+
+## Phase 4: User Story 2 — Continuing an Existing Conversation (Priority: P2)
+
+**Goal**: A follow-up question submitted with a valid `ConversationId` is linked to the existing `Conversation` record rather than creating a new one. An invalid or foreign `ConversationId` silently falls back to a new conversation.
+
+**Independent Test**: Run the two new unit tests T016–T017; or POST two questions with the same `ConversationId` and verify `GetConversationsAsync` returns one conversation with two questions.
+
+### Verification — User Story 2 ⚠️
+
+- [X] T016 [P] [US2] Add unit test `AskAsync_WithValidConversationId_ReusesThatConversation` in `backend/test/backend.Tests/RagServiceTests/RagAppServiceTests.cs` — asserts `LastConversationId == suppliedId` when the ID belongs to the current user
+- [X] T017 [P] [US2] Add unit test `AskAsync_WithConversationIdBelongingToAnotherUser_CreatesNewConversation` in `backend/test/backend.Tests/RagServiceTests/RagAppServiceTests.cs` — asserts a new `Conversation` is created (ownership check enforced)
+- [X] T018 [P] [US2] Add unit test `AskAsync_WithNullConversationId_CreatesNewConversation` in `backend/test/backend.Tests/RagServiceTests/RagAppServiceTests.cs` — asserts baseline behaviour still works when no ID is supplied
+
+### Implementation — User Story 2
+
+No additional implementation code is required beyond what was written in Phase 3 (T011 already contains the conversation lookup + ownership check + fallback logic). Phase 4 is purely verification.
+
+- [X] T019 [US2] Run full test suite `dotnet test backend/backend.sln --filter "RagServiceTests"` and confirm T016, T017, T018 all pass alongside existing tests
+
+**Checkpoint**: Conversation reuse is verified working; ownership guard confirmed; multi-turn architecture is functional.
+
+---
+
+## Phase 5: User Story 3 — Admin Analytics Access (Priority: P3)
+
+**Goal**: Stored interaction records are queryable by date range and language. No new code is required since the schema, indexes, and `GetConversationsAsync` already exist. Verification confirms query correctness.
+
+**Independent Test**: After seeding multiple Q&A interactions, call `GetConversationsAsync` and confirm filtering by `UserId` and ordering by `StartedAt` returns correct results.
+
+### Verification — User Story 3 ⚠️
+
+- [X] T020 [US3] Add unit test `GetConversationsAsync_ReturnsOnlyCurrentUserConversations_OrderedByStartedAtDescending` in `backend/test/backend.Tests/RagServiceTests/RagAppServiceTests.cs` — seeds two conversations for different users, asserts only the current user's appear, ordered newest-first
+- [X] T021 [US3] Add unit test `GetConversationsAsync_IncludesFirstQuestionAndCount` in `backend/test/backend.Tests/RagServiceTests/RagAppServiceTests.cs` — asserts `ConversationSummaryDto.FirstQuestion` and `QuestionCount` are populated correctly
+
+### Implementation — User Story 3
+
+No new implementation code. All analytics queries are satisfied by the existing `GetConversationsAsync` method and database indexes.
+
+- [X] T022 [US3] Run `dotnet test backend/backend.sln --filter "RagServiceTests"` and confirm T020, T021 pass
+
+**Checkpoint**: All three user stories verified; entire test suite is green.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [X] T023 [P] Update XML doc comment on `IRagAppService.AskAsync` in `backend/src/backend.Application/Services/RagService/IRagAppService.cs` to document the new optional `ConversationId` parameter on the request
+- [X] T024 [P] Confirm `GetConversationsAsync` controller action in `backend/src/backend.Web.Host/Controllers/QuestionController.cs` is publicly documented and returns the conversation ID so clients can send it on follow-up questions
+- [ ] T025 Run quickstart manual verification steps from `specs/feat/023-persist-qa-records/quickstart.md` against a running local backend to confirm end-to-end behaviour
+- [ ] T026 [P] Run `dotnet test backend/backend.sln` (full suite) and confirm zero regressions across all test projects
+- [ ] T027 Commit all changes on branch `feat/023-persist-qa-records` following the `follow-git-workflow` skill conventions
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```
+Phase 1 (Setup)        → no dependencies → start immediately
+Phase 2 (Foundational) → depends on Phase 1 → BLOCKS all story phases
+Phase 3 (US1 / P1)    → depends on Phase 2
+Phase 4 (US2 / P2)    → depends on Phase 3 (reuses conversation logic from T011)
+Phase 5 (US3 / P3)    → depends on Phase 2 (schema already exists; independent of US1/US2 logic)
+Phase 6 (Polish)       → depends on Phases 3–5 all passing
+```
+
+### Within Each Phase
+
+```
+T003 → T004                             (foundational spy update)
+T005, T006 (parallel) → T007–T014 → T015   (US1: tests first, then implement, then build)
+T016, T017, T018 (parallel) → T019        (US2: tests first, all parallel, then run suite)
+T020, T021 (parallel) → T022             (US3: tests first, then run suite)
+```
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel (different commands)
+- T005 and T006 can be written in parallel (different test methods)
+- T007 and T008 can be written in parallel (different DTOs)
+- T016, T017, T018 can be written in parallel (different test methods)
+- T020, T021 can be written in parallel (different test methods)
+- T023, T024, T026 can run in parallel (different files)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Step 1 – write verification tests in parallel (T005, T006):
+Agent A: AskAsync_AuthenticatedGroundedAnswer_AnswerAndCitationsArePersisted
+Agent B: AskAsync_AnonymousUser_NoPersistenceOccurs
+
+# Step 2 – implement DTO changes in parallel (T007, T008):
+Agent A: AskQuestionRequest.cs — add ConversationId property
+Agent B: RagAnswerResult.cs — add ConversationId property
+
+# Step 3 – implement service changes sequentially (T009→T010→T011→T012→T013→T014):
+Agent A: RagAppService.cs — all changes sequential (same file)
+
+# Step 4 – build check (T015):
+dotnet build backend/backend.sln
+```
+
+---
+
+## Implementation Strategy
+
+### MVP: User Story 1 Only (Phases 1–3)
+
+1. Complete Phase 1: Setup — confirm green build
+2. Complete Phase 2: Foundational — update `TestableRagAppService`
+3. Complete Phase 3: User Story 1 — write tests, implement DTO + service changes, run build
+4. **STOP and VALIDATE**: `dotnet test --filter "RagServiceTests"` all green; all four record types confirmed in database
+5. Deploy / demo if ready
+
+### Incremental Delivery
+
+- Phase 3 complete → persistence works (MVP ✅)
+- Phase 4 complete → multi-turn conversations work
+- Phase 5 complete → admin analytics confirmed queryable
+- Phase 6 complete → documented, committed, regression-free
+
+---
+
+## Notes
+
+- No new migrations needed — all entities and indexes already exist
+- [P] = different files, safe to parallelize
+- [US1/US2/US3] maps tasks to spec.md user stories for traceability
+- Commit after each logical group (foundation, US1, US2, US3)
+- Stop at each Checkpoint to validate independence before proceeding


### PR DESCRIPTION
- Updated `AskQuestionRequest` and `RagAnswerResult` DTOs to include `ConversationId`.
- Enhanced `PersistQuestionAsync` to handle conversation reuse based on `ConversationId`.
- Added unit tests to verify persistence of questions, answers, and citations for authenticated users.
- Implemented logic to create new conversations or reuse existing ones based on the provided `ConversationId`.
- Updated `GetConversationsAsync` to return only the current user's conversations, including the first question and count.
- Refactored test infrastructure to track conversation IDs in `TestableRagAppService`.
- Improved error handling and fallback mechanisms for API requests in the frontend service.