### PR TITLE
Dev

### DIFF
--- a/backend/src/backend.Application/Services/ContractService/ContractAppService.cs
+++ b/backend/src/backend.Application/Services/ContractService/ContractAppService.cs
@@ -126,7 +126,8 @@ public class ContractAppService : ApplicationService, IContractAppService
         return await _contractFollowUpService.AskAsync(
             analysis,
             request.QuestionText,
-            request.ResponseLanguageCode);
+            request.ResponseLanguageCode,
+            request.ConversationHistory);
     }
 
     protected virtual async Task<ContractAnalysis> GetOwnedAnalysisAsync(Guid id)

--- a/backend/src/backend.Application/Services/ContractService/ContractFollowUpService.cs
+++ b/backend/src/backend.Application/Services/ContractService/ContractFollowUpService.cs
@@ -23,6 +23,8 @@ namespace backend.Services.ContractService;
 /// </summary>
 public class ContractFollowUpService : ApplicationService
 {
+    private const int MaxConversationHistoryMessages = 6;
+
     private static readonly HashSet<string> UrgentTerms = new(StringComparer.Ordinal)
     {
         "asap", "deadline", "evict", "eviction", "hearing", "immediately", "lockout", "urgent"
@@ -76,7 +78,8 @@ public class ContractFollowUpService : ApplicationService
     public virtual async Task<ContractFollowUpAnswerDto> AskAsync(
         ContractAnalysis analysis,
         string questionText,
-        string responseLanguageCode = null)
+        string responseLanguageCode = null,
+        IReadOnlyList<ContractConversationHistoryMessageDto> conversationHistory = null)
     {
         Guard.Against.Null(analysis, nameof(analysis));
         Guard.Against.NullOrWhiteSpace(questionText, nameof(questionText));
@@ -87,13 +90,14 @@ public class ContractFollowUpService : ApplicationService
         var responseLanguage = string.IsNullOrWhiteSpace(responseLanguageCode)
             ? detectedLanguage
             : ContractAnalysisService.ParseLanguageCode(responseLanguageCode);
-        var requiresUrgentAttention = RequiresUrgentAttention(translatedQuestionText);
+        var retrievalQuestionText = BuildRetrievalQuestionText(translatedQuestionText, conversationHistory);
+        var requiresUrgentAttention = RequiresUrgentAttention(retrievalQuestionText);
 
-        var contractExcerpts = SelectRelevantExcerpts(analysis.ExtractedText, translatedQuestionText);
+        var contractExcerpts = SelectRelevantExcerpts(analysis.ExtractedText, retrievalQuestionText);
         var context = await _contractLegislationContextBuilder.BuildForFollowUpAsync(
             analysis.ContractType,
             analysis.ExtractedText,
-            translatedQuestionText);
+            retrievalQuestionText);
         var (answerMode, confidenceBand) = DetermineAnswerMode(context, contractExcerpts.Count, requiresUrgentAttention);
 
         if (answerMode == RagAnswerMode.Insufficient)
@@ -112,7 +116,8 @@ public class ContractFollowUpService : ApplicationService
             answerMode,
             contractExcerpts,
             context,
-            requiresUrgentAttention);
+            requiresUrgentAttention,
+            conversationHistory);
 
         return new ContractFollowUpAnswerDto
         {
@@ -200,7 +205,8 @@ public class ContractFollowUpService : ApplicationService
         RagAnswerMode answerMode,
         IReadOnlyList<string> contractExcerpts,
         ContractLegislationContext context,
-        bool requiresUrgentAttention)
+        bool requiresUrgentAttention,
+        IReadOnlyList<ContractConversationHistoryMessageDto> conversationHistory)
     {
         var systemPrompt = BuildSystemPrompt(answerMode, responseLanguage, requiresUrgentAttention);
         var userPrompt = BuildUserPrompt(
@@ -209,7 +215,8 @@ public class ContractFollowUpService : ApplicationService
             answerMode,
             contractExcerpts,
             context,
-            requiresUrgentAttention);
+            requiresUrgentAttention,
+            conversationHistory);
 
         return await CallChatCompletionsAsync(
             systemPrompt,
@@ -311,16 +318,17 @@ public class ContractFollowUpService : ApplicationService
             "2. Include citations for every material legal claim in the format [Act Name, Section X].\n" +
             "3. If the support is limited, say so clearly instead of overstating certainty.\n" +
             "4. Keep the answer practical, plain-language, and focused on what the clause means for the user.\n" +
-            "5. Keep Act names, section numbers, and quoted clause text in English.";
+            "5. Keep Act names, section numbers, and quoted clause text in English.\n" +
+            "6. Conversation history may help you resolve follow-up references like 'that clause', but prior assistant replies are not legal authority.";
 
         if (answerMode == RagAnswerMode.Cautious)
         {
-            prompt += "\n6. Lead with what is uncertain or needs review before giving the grounded answer.";
+            prompt += "\n7. Lead with what is uncertain or needs review before giving the grounded answer.";
         }
 
         if (requiresUrgentAttention)
         {
-            prompt += "\n7. Add a short immediate-help note if the situation may involve urgent deadlines, lockout, eviction, or immediate harm.";
+            prompt += "\n8. Add a short immediate-help note if the situation may involve urgent deadlines, lockout, eviction, or immediate harm.";
         }
 
         var languageDirective = responseLanguage switch
@@ -333,7 +341,7 @@ public class ContractFollowUpService : ApplicationService
 
         if (!string.IsNullOrWhiteSpace(languageDirective))
         {
-            prompt += $"\n8. {languageDirective}";
+            prompt += $"\n9. {languageDirective}";
         }
 
         return prompt;
@@ -345,12 +353,17 @@ public class ContractFollowUpService : ApplicationService
         RagAnswerMode answerMode,
         IReadOnlyList<string> contractExcerpts,
         ContractLegislationContext context,
-        bool requiresUrgentAttention)
+        bool requiresUrgentAttention,
+        IReadOnlyList<ContractConversationHistoryMessageDto> conversationHistory)
     {
         var contractTextBlock = string.Join(
             "\n\n",
             contractExcerpts.Select((excerpt, index) => $"Contract excerpt {index + 1}:\n{excerpt}"));
         var legislationContextBlock = ContractPromptBuilder.BuildContextBlock(context.AllChunks);
+        var conversationHistoryBlock = BuildConversationHistoryBlock(conversationHistory);
+        var historyPrefix = string.IsNullOrWhiteSpace(conversationHistoryBlock)
+            ? string.Empty
+            : $"Conversation history for continuity only (not legal authority):\n\n{conversationHistoryBlock}\n\n";
         var answerLead = answerMode == RagAnswerMode.Cautious
             ? "Answer carefully. Explain what is clear, what is uncertain, and what should be reviewed."
             : "Answer directly using the contract excerpts and legislation context only.";
@@ -365,11 +378,55 @@ public class ContractFollowUpService : ApplicationService
             $"Contract type: {ContractPromptBuilder.ToContractTypeValue(analysis.ContractType)}\n" +
             $"Coverage state: {context.CoverageState}\n" +
             $"Coverage notes: {context.CoverageNotes}\n\n" +
+            historyPrefix +
             $"Relevant contract excerpts:\n\n{contractTextBlock}\n\n" +
             $"Legislation context:\n\n{legislationContextBlock}\n\n" +
             $"Follow-up question: {originalQuestionText}\n\n" +
             $"{answerLead}\n\n" +
             "Answer:";
+    }
+
+    private static string BuildConversationHistoryBlock(IReadOnlyList<ContractConversationHistoryMessageDto> conversationHistory)
+    {
+        if (conversationHistory is null || conversationHistory.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var entries = conversationHistory
+            .Where(message =>
+                message is not null &&
+                !string.IsNullOrWhiteSpace(message.Text) &&
+                (string.Equals(message.Role, "user", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(message.Role, "assistant", StringComparison.OrdinalIgnoreCase)))
+            .TakeLast(MaxConversationHistoryMessages)
+            .Select(message =>
+            {
+                var roleLabel = string.Equals(message.Role, "assistant", StringComparison.OrdinalIgnoreCase)
+                    ? "Assistant"
+                    : "User";
+                return $"{roleLabel}: {message.Text.Trim()}";
+            })
+            .ToList();
+
+        return entries.Count == 0
+            ? string.Empty
+            : string.Join("\n\n", entries);
+    }
+
+    private static string BuildRetrievalQuestionText(
+        string translatedQuestionText,
+        IReadOnlyList<ContractConversationHistoryMessageDto> conversationHistory)
+    {
+        var conversationHistoryBlock = BuildConversationHistoryBlock(conversationHistory);
+        if (string.IsNullOrWhiteSpace(conversationHistoryBlock))
+        {
+            return translatedQuestionText;
+        }
+
+        return
+            $"Current follow-up question: {translatedQuestionText.Trim()}\n\n" +
+            $"Recent contract conversation context:\n{conversationHistoryBlock}";
     }
 
     private sealed record OpenAiChatRequest(

--- a/backend/src/backend.Application/Services/ContractService/DTO/AskContractQuestionRequest.cs
+++ b/backend/src/backend.Application/Services/ContractService/DTO/AskContractQuestionRequest.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace backend.Services.ContractService.DTO;
 
 /// <summary>
@@ -8,4 +10,6 @@ public class AskContractQuestionRequest
     public string QuestionText { get; set; }
 
     public string ResponseLanguageCode { get; set; }
+
+    public List<ContractConversationHistoryMessageDto> ConversationHistory { get; set; } = new();
 }

--- a/backend/src/backend.Application/Services/ContractService/DTO/ContractConversationHistoryMessageDto.cs
+++ b/backend/src/backend.Application/Services/ContractService/DTO/ContractConversationHistoryMessageDto.cs
@@ -1,0 +1,11 @@
+namespace backend.Services.ContractService.DTO;
+
+/// <summary>
+/// One contract follow-up message used to preserve conversational context.
+/// </summary>
+public class ContractConversationHistoryMessageDto
+{
+    public string Role { get; set; }
+
+    public string Text { get; set; }
+}

--- a/backend/src/backend.Application/Services/RagService/DTO/ConversationDetailDto.cs
+++ b/backend/src/backend.Application/Services/RagService/DTO/ConversationDetailDto.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace backend.Services.RagService.DTO;
+
+/// <summary>
+/// Full stored conversation returned to history and chat rehydration consumers.
+/// </summary>
+public class ConversationDetailDto
+{
+    public Guid ConversationId { get; set; }
+
+    public DateTime StartedAt { get; set; }
+
+    public string Language { get; set; } = "en";
+
+    public int QuestionCount { get; set; }
+
+    public List<ConversationHistoryMessageDto> Messages { get; set; } = new();
+}

--- a/backend/src/backend.Application/Services/RagService/DTO/ConversationHistoryMessageDto.cs
+++ b/backend/src/backend.Application/Services/RagService/DTO/ConversationHistoryMessageDto.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace backend.Services.RagService.DTO;
+
+/// <summary>
+/// One stored conversation message returned for history and thread rehydration.
+/// </summary>
+public class ConversationHistoryMessageDto
+{
+    public Guid MessageId { get; set; }
+
+    public string Type { get; set; } = "user";
+
+    public string Text { get; set; } = string.Empty;
+
+    public DateTime CreatedAt { get; set; }
+
+    public string DetectedLanguageCode { get; set; } = "en";
+
+    public List<RagCitationDto> Citations { get; set; } = new();
+}

--- a/backend/src/backend.Application/Services/RagService/DTO/RagAnswerResult.cs
+++ b/backend/src/backend.Application/Services/RagService/DTO/RagAnswerResult.cs
@@ -38,13 +38,13 @@ public class RagAnswerResult
 
     /// <summary>
     /// ID of the persisted <see cref="backend.Domains.QA.Answer"/> entity created for this Q&amp;A exchange.
-    /// <c>null</c> when no grounded answer record was created.
+    /// <c>null</c> when no answer record was created, such as an anonymous exchange.
     /// </summary>
     public Guid? AnswerId { get; set; }
 
     /// <summary>
     /// ID of the persisted <see cref="backend.Domains.QA.Conversation"/> linked to this exchange.
-    /// <c>null</c> when no conversation was persisted or surfaced to the client.
+    /// <c>null</c> when no conversation was persisted or surfaced to the client, such as an anonymous exchange.
     /// </summary>
     public Guid? ConversationId { get; set; }
 
@@ -54,6 +54,32 @@ public class RagAnswerResult
     /// </summary>
     [JsonProperty("detectedLanguageCode")]
     public string DetectedLanguageCode { get; set; } = "en";
+
+    /// <summary>
+    /// Preferred title of the controlling source selected for the response posture.
+    /// Null when the system could not safely settle on a governing source.
+    /// </summary>
+    [JsonProperty("primarySourceTitle")]
+    public string PrimarySourceTitle { get; set; }
+
+    /// <summary>
+    /// Preferred locator of the controlling source such as a section number or heading.
+    /// Null when the system could not safely settle on a governing source.
+    /// </summary>
+    [JsonProperty("primarySourceLocator")]
+    public string PrimarySourceLocator { get; set; }
+
+    /// <summary>
+    /// Distinguishes whether the controlling source is binding law or official guidance.
+    /// </summary>
+    [JsonProperty("primaryAuthorityType")]
+    public string PrimaryAuthorityType { get; set; }
+
+    /// <summary>
+    /// True when the response includes one or more supporting sources beyond the controlling source.
+    /// </summary>
+    [JsonProperty("hasSupportingSources")]
+    public bool HasSupportingSources { get; set; }
 
     /// <summary>
     /// Structured response posture returned by the retrieval pipeline.

--- a/backend/src/backend.Application/Services/RagService/IRagAppService.cs
+++ b/backend/src/backend.Application/Services/RagService/IRagAppService.cs
@@ -1,5 +1,6 @@
 using Abp.Application.Services;
 using backend.Services.RagService.DTO;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -34,6 +35,11 @@ public interface IRagAppService : IApplicationService
     /// and the total number of questions in that conversation.
     /// </summary>
     Task<ConversationsListDto> GetConversationsAsync();
+
+    /// <summary>
+    /// Returns the full stored thread for one authenticated user's conversation.
+    /// </summary>
+    Task<ConversationDetailDto> GetConversationAsync(Guid conversationId);
 
     /// <summary>
     /// Loads all <see cref="backend.Domains.LegalDocuments.DocumentChunk"/> embeddings into memory.

--- a/backend/src/backend.Application/Services/RagService/RagAppService.cs
+++ b/backend/src/backend.Application/Services/RagService/RagAppService.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,11 +24,12 @@ namespace backend.Services.RagService;
 /// <summary>
 /// Core RAG orchestration service for South African legal Q&amp;A.
 /// Loads chunk embeddings and source metadata into memory, plans document-aware retrieval,
-/// calls the chat model only when grounding is adequate, persists question history for
-/// authenticated users, and stores answers only for grounded outcomes.
+/// calls the chat model only when grounding is adequate, persists conversation history for
+/// authenticated users, and can rehydrate stored threads back into the client.
 /// </summary>
 public class RagAppService : ApplicationService, IRagAppService
 {
+    private const int MaxConversationHistoryMessages = 6;
     private readonly IEmbeddingAppService _embeddingService;
     private readonly ILanguageAppService _languageService;
     private readonly IRepository<DocumentChunk, Guid> _chunkRepository;
@@ -157,6 +159,20 @@ public class RagAppService : ApplicationService, IRagAppService
         return new ConversationsListDto { Items = items, TotalCount = items.Count };
     }
 
+    public async Task<ConversationDetailDto> GetConversationAsync(Guid conversationId)
+    {
+        var userId = AbpSession.UserId
+            ?? throw new Abp.Authorization.AbpAuthorizationException("You must be signed in to view conversation history.");
+
+        var conversation = await LoadConversationThreadAsync(userId, conversationId);
+        if (conversation is null)
+        {
+            throw new Abp.Authorization.AbpAuthorizationException("Conversation not found.");
+        }
+
+        return MapConversationDetail(conversation);
+    }
+
     public async Task<RagAnswerResult> AskAsync(AskQuestionRequest request)
     {
         Guard.Against.Null(request, nameof(request));
@@ -165,14 +181,19 @@ public class RagAppService : ApplicationService, IRagAppService
         await EnsureIndexLoadedAsync();
 
         var userId = AbpSession.UserId;
+        var existingConversation = userId.HasValue && request.ConversationId.HasValue
+            ? await LoadConversationThreadAsync(userId.Value, request.ConversationId.Value)
+            : null;
         var detectedLanguage = await _languageService.DetectLanguageAsync(request.QuestionText);
         var translatedText = await _languageService.TranslateToEnglishAsync(request.QuestionText, detectedLanguage);
         var detectedLanguageCode = RagPromptBuilder.ToIsoCode(detectedLanguage);
-        var embeddingResult = await _embeddingService.GenerateEmbeddingAsync(translatedText);
-        var focusQueryText = RagQueryFocusBuilder.Build(translatedText);
+        var conversationHistoryBlock = BuildConversationHistoryBlock(existingConversation);
+        var retrievalQuestionText = BuildRetrievalQuestionText(translatedText, conversationHistoryBlock);
+        var embeddingResult = await _embeddingService.GenerateEmbeddingAsync(retrievalQuestionText);
+        var focusQueryText = RagQueryFocusBuilder.Build(retrievalQuestionText);
         float[] focusVector = null;
         if (!string.IsNullOrWhiteSpace(focusQueryText) &&
-            !string.Equals(focusQueryText, translatedText, StringComparison.OrdinalIgnoreCase))
+            !string.Equals(focusQueryText, retrievalQuestionText, StringComparison.OrdinalIgnoreCase))
         {
             focusVector = (await _embeddingService.GenerateEmbeddingAsync(focusQueryText)).Vector;
         }
@@ -184,31 +205,46 @@ public class RagAppService : ApplicationService, IRagAppService
             embeddingResult.Vector,
             loadedChunks,
             focusVector);
-        var sourceHints = _sourceHintExtractor.Extract(translatedText, loadedChunks);
+        var sourceHints = _sourceHintExtractor.Extract(retrievalQuestionText, loadedChunks);
         var retrievalPlan = _retrievalPlanner.BuildPlan(
-            translatedText,
+            retrievalQuestionText,
             embeddingResult.Vector,
             semanticMatches,
             sourceHints,
             documentProfiles);
-        var retrievalDecision = _confidenceEvaluator.Evaluate(translatedText, retrievalPlan);
+        var retrievalDecision = _confidenceEvaluator.Evaluate(retrievalQuestionText, retrievalPlan);
+        Guid? answerId = null;
+        Guid? conversationId = null;
 
         if (retrievalDecision.AnswerMode == RagAnswerMode.Insufficient)
         {
-            await PersistQuestionIfAuthenticatedAsync(
-                userId,
-                request.ConversationId,
-                request.QuestionText,
-                translatedText,
-                detectedLanguage);
-
-            return BuildNonGroundedResult(
+            var result = BuildNonGroundedResult(
                 detectedLanguage,
                 detectedLanguageCode,
                 RagAnswerMode.Insufficient,
                 retrievalDecision.ConfidenceBand,
                 null,
                 retrievalDecision.RequiresUrgentAttention);
+
+            if (userId.HasValue)
+            {
+                var persistedQuestion = await PersistQuestionAsync(
+                    userId.Value,
+                    existingConversation?.Id,
+                    request.QuestionText,
+                    translatedText,
+                    detectedLanguage);
+                conversationId = persistedQuestion.ConversationId;
+                answerId = await PersistAnswerAsync(
+                    persistedQuestion.QuestionId,
+                    result.AnswerText,
+                    detectedLanguage,
+                    Array.Empty<RetrievedChunk>());
+                result.ConversationId = conversationId;
+                result.AnswerId = answerId;
+            }
+
+            return result;
         }
 
         if (retrievalDecision.AnswerMode == RagAnswerMode.Clarification)
@@ -216,36 +252,48 @@ public class RagAppService : ApplicationService, IRagAppService
             var clarificationQuestion = await BuildClarificationQuestionAsync(
                 request.QuestionText,
                 detectedLanguage,
-                retrievalDecision);
+                retrievalDecision,
+                conversationHistoryBlock);
 
-            await PersistQuestionIfAuthenticatedAsync(
-                userId,
-                request.ConversationId,
-                request.QuestionText,
-                translatedText,
-                detectedLanguage);
-
-            return BuildNonGroundedResult(
+            var result = BuildNonGroundedResult(
                 detectedLanguage,
                 detectedLanguageCode,
                 RagAnswerMode.Clarification,
                 retrievalDecision.ConfidenceBand,
                 clarificationQuestion,
                 retrievalDecision.RequiresUrgentAttention);
+
+            if (userId.HasValue)
+            {
+                var persistedQuestion = await PersistQuestionAsync(
+                    userId.Value,
+                    existingConversation?.Id,
+                    request.QuestionText,
+                    translatedText,
+                    detectedLanguage);
+                conversationId = persistedQuestion.ConversationId;
+                answerId = await PersistAnswerAsync(
+                    persistedQuestion.QuestionId,
+                    BuildStoredClarificationAnswer(result.AnswerText, clarificationQuestion),
+                    detectedLanguage,
+                    Array.Empty<RetrievedChunk>());
+                result.ConversationId = conversationId;
+                result.AnswerId = answerId;
+            }
+
+            return result;
         }
 
         var answerText = await BuildGroundedAnswerAsync(
             request.QuestionText,
             detectedLanguage,
-            retrievalDecision);
-
-        Guid? answerId = null;
-        Guid? conversationId = null;
+            retrievalDecision,
+            conversationHistoryBlock);
         if (userId.HasValue)
         {
             var persistedQuestion = await PersistQuestionAsync(
                 userId.Value,
-                request.ConversationId,
+                existingConversation?.Id,
                 request.QuestionText,
                 translatedText,
                 detectedLanguage);
@@ -272,27 +320,20 @@ public class RagAppService : ApplicationService, IRagAppService
             DetectedLanguageCode = detectedLanguageCode,
             AnswerMode = retrievalDecision.AnswerMode,
             ConfidenceBand = retrievalDecision.ConfidenceBand,
+            PrimarySourceTitle = GetPrimarySourceTitle(retrievalDecision.SelectedChunks),
+            PrimarySourceLocator = GetPrimarySourceLocator(retrievalDecision.SelectedChunks),
+            PrimaryAuthorityType = GetPrimaryAuthorityType(retrievalDecision.SelectedChunks),
+            HasSupportingSources = retrievalDecision.SelectedChunks.Any(chunk =>
+                string.Equals(chunk.SourceRole, RagSourceMetadata.Supporting, StringComparison.Ordinal)),
             RequiresUrgentAttention = retrievalDecision.RequiresUrgentAttention
         };
     }
 
     public static bool ShouldPersistAnswer(RagAnswerMode answerMode) =>
-        answerMode == RagAnswerMode.Direct || answerMode == RagAnswerMode.Cautious;
-
-    private async Task PersistQuestionIfAuthenticatedAsync(
-        long? userId,
-        Guid? conversationId,
-        string originalText,
-        string translatedText,
-        Language language)
-    {
-        if (!userId.HasValue)
-        {
-            return;
-        }
-
-        await PersistQuestionAsync(userId.Value, conversationId, originalText, translatedText, language);
-    }
+        answerMode == RagAnswerMode.Direct ||
+        answerMode == RagAnswerMode.Cautious ||
+        answerMode == RagAnswerMode.Clarification ||
+        answerMode == RagAnswerMode.Insufficient;
 
     private async Task EnsureIndexLoadedAsync()
     {
@@ -326,6 +367,10 @@ public class RagAppService : ApplicationService, IRagAppService
             DetectedLanguageCode = detectedLanguageCode,
             AnswerMode = answerMode,
             ConfidenceBand = confidenceBand,
+            PrimarySourceTitle = null,
+            PrimarySourceLocator = null,
+            PrimaryAuthorityType = null,
+            HasSupportingSources = false,
             ClarificationQuestion = answerMode == RagAnswerMode.Clarification ? clarificationQuestion : null,
             RequiresUrgentAttention = requiresUrgentAttention
         };
@@ -334,7 +379,8 @@ public class RagAppService : ApplicationService, IRagAppService
     private async Task<string> BuildGroundedAnswerAsync(
         string originalQuestionText,
         Language detectedLanguage,
-        RetrievalDecision retrievalDecision)
+        RetrievalDecision retrievalDecision,
+        string conversationHistoryBlock)
     {
         var systemPrompt = RagPromptBuilder.BuildSystemPrompt(
             retrievalDecision.AnswerMode,
@@ -345,6 +391,7 @@ public class RagAppService : ApplicationService, IRagAppService
             originalQuestionText,
             contextBlock,
             retrievalDecision.AnswerMode,
+            conversationHistoryBlock: conversationHistoryBlock,
             requiresUrgentAttention: retrievalDecision.RequiresUrgentAttention);
 
         return await CallChatCompletionsAsync(
@@ -356,7 +403,8 @@ public class RagAppService : ApplicationService, IRagAppService
     private async Task<string> BuildClarificationQuestionAsync(
         string originalQuestionText,
         Language detectedLanguage,
-        RetrievalDecision retrievalDecision)
+        RetrievalDecision retrievalDecision,
+        string conversationHistoryBlock)
     {
         if (retrievalDecision.SelectedChunks.Count == 0)
         {
@@ -375,6 +423,7 @@ public class RagAppService : ApplicationService, IRagAppService
                 contextBlock,
                 RagAnswerMode.Clarification,
                 retrievalDecision.ClarificationQuestion,
+                conversationHistoryBlock,
                 retrievalDecision.RequiresUrgentAttention);
 
             var response = await CallChatCompletionsAsync(
@@ -528,6 +577,161 @@ public class RagAppService : ApplicationService, IRagAppService
                 RelevanceScore = chunk.RelevanceScore
             })
             .ToList();
+
+    private static RetrievedChunk GetPrimarySourceChunk(IEnumerable<RetrievedChunk> usedChunks) =>
+        usedChunks?
+            .FirstOrDefault(chunk =>
+                string.Equals(chunk.SourceRole, RagSourceMetadata.Primary, StringComparison.Ordinal)) ??
+        usedChunks?
+            .FirstOrDefault();
+
+    private static string BuildStoredClarificationAnswer(string answerLead, string clarificationQuestion)
+    {
+        if (string.IsNullOrWhiteSpace(clarificationQuestion))
+        {
+            return answerLead;
+        }
+
+        return $"{answerLead}\n\n{clarificationQuestion.Trim()}";
+    }
+
+    private static string BuildRetrievalQuestionText(string translatedQuestionText, string conversationHistoryBlock)
+    {
+        if (string.IsNullOrWhiteSpace(conversationHistoryBlock))
+        {
+            return translatedQuestionText;
+        }
+
+        return
+            $"Current question: {translatedQuestionText.Trim()}\n\n" +
+            $"Recent conversation context:\n{conversationHistoryBlock}";
+    }
+
+    private static string BuildConversationHistoryBlock(Conversation conversation)
+    {
+        var messageEntries = conversation?.Questions?
+            .OrderBy(question => question.CreationTime)
+            .SelectMany(question =>
+            {
+                var entries = new List<(DateTime CreatedAt, string Role, string Text)>
+                {
+                    (question.CreationTime, "User", question.OriginalText ?? string.Empty)
+                };
+
+                if (question.Answers != null)
+                {
+                    entries.AddRange(question.Answers
+                        .OrderBy(answer => answer.CreationTime)
+                        .Select(answer => (answer.CreationTime, "Assistant", answer.Text ?? string.Empty)));
+                }
+
+                return entries;
+            })
+            .OrderBy(entry => entry.CreatedAt)
+            .TakeLast(MaxConversationHistoryMessages)
+            .ToList();
+
+        if (messageEntries is null || messageEntries.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        foreach (var entry in messageEntries)
+        {
+            var text = entry.Text.Trim();
+            if (text.Length > 500)
+            {
+                text = $"{text[..500]}...";
+            }
+
+            sb.AppendLine($"{entry.Role}: {text}");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string GetPrimarySourceTitle(IEnumerable<RetrievedChunk> usedChunks) =>
+        GetPrimarySourceChunk(usedChunks)?.SourceTitle;
+
+    private static string GetPrimarySourceLocator(IEnumerable<RetrievedChunk> usedChunks) =>
+        GetPrimarySourceChunk(usedChunks)?.SourceLocator;
+
+    private static string GetPrimaryAuthorityType(IEnumerable<RetrievedChunk> usedChunks) =>
+        GetPrimarySourceChunk(usedChunks)?.AuthorityType;
+
+    protected virtual Task<Conversation> LoadConversationThreadAsync(long userId, Guid conversationId)
+    {
+        return _conversationRepository
+            .GetAll()
+            .Include(conversation => conversation.Questions)
+                .ThenInclude(question => question.Answers)
+                    .ThenInclude(answer => answer.Citations)
+                        .ThenInclude(citation => citation.Chunk)
+                            .ThenInclude(chunk => chunk.Document)
+            .FirstOrDefaultAsync(conversation =>
+                conversation.Id == conversationId &&
+                conversation.UserId == userId);
+    }
+
+    private static ConversationDetailDto MapConversationDetail(Conversation conversation)
+    {
+        var messages = new List<ConversationHistoryMessageDto>();
+
+        foreach (var question in conversation.Questions.OrderBy(item => item.CreationTime))
+        {
+            messages.Add(new ConversationHistoryMessageDto
+            {
+                MessageId = question.Id,
+                Type = "user",
+                Text = question.OriginalText ?? string.Empty,
+                CreatedAt = question.CreationTime,
+                DetectedLanguageCode = RagPromptBuilder.ToIsoCode(question.Language),
+                Citations = new List<RagCitationDto>()
+            });
+
+            foreach (var answer in (question.Answers ?? Array.Empty<Answer>()).OrderBy(item => item.CreationTime))
+            {
+                messages.Add(new ConversationHistoryMessageDto
+                {
+                    MessageId = answer.Id,
+                    Type = "bot",
+                    Text = answer.Text ?? string.Empty,
+                    CreatedAt = answer.CreationTime,
+                    DetectedLanguageCode = RagPromptBuilder.ToIsoCode(answer.Language),
+                    Citations = (answer.Citations ?? Array.Empty<AnswerCitation>())
+                        .OrderByDescending(citation => citation.RelevanceScore)
+                        .Select(citation => new RagCitationDto
+                        {
+                            ChunkId = citation.ChunkId,
+                            ActName = citation.Chunk?.Document?.Title ?? "Unknown Act",
+                            SectionNumber = citation.SectionNumber,
+                            SourceTitle = citation.Chunk?.Document?.Title ?? "Unknown Act",
+                            SourceLocator = citation.SectionNumber,
+                            AuthorityType = citation.Chunk?.Document is null
+                                ? null
+                                : RagSourceMetadata.DeriveAuthorityType(
+                                    citation.Chunk.Document.Title,
+                                    citation.Chunk.Document.ShortName,
+                                    citation.Chunk.Document.ActNumber),
+                            SourceRole = null,
+                            Excerpt = citation.Excerpt,
+                            RelevanceScore = (float)citation.RelevanceScore
+                        })
+                        .ToList()
+                });
+            }
+        }
+
+        return new ConversationDetailDto
+        {
+            ConversationId = conversation.Id,
+            StartedAt = conversation.StartedAt,
+            Language = conversation.Language.ToString().ToLowerInvariant(),
+            QuestionCount = conversation.Questions?.Count ?? 0,
+            Messages = messages
+        };
+    }
 
     private static List<string> ParseKeywords(string rawKeywords)
     {

--- a/backend/src/backend.Application/Services/RagService/RagConfidenceEvaluator.cs
+++ b/backend/src/backend.Application/Services/RagService/RagConfidenceEvaluator.cs
@@ -8,6 +8,11 @@ namespace backend.Services.RagService;
 
 public sealed class RagConfidenceEvaluator
 {
+    private static readonly HashSet<string> BindingLawExpectationTerms = new(StringComparer.Ordinal)
+    {
+        "act", "acts", "law", "laws", "legal", "legislation", "regulation", "regulations", "section", "sections", "statute", "statutory"
+    };
+
     private static readonly HashSet<string> TemporalUrgencyTerms = new(StringComparer.Ordinal)
     {
         "asap", "deadline", "immediately", "now", "today", "tomorrow", "tonight", "urgent"
@@ -42,8 +47,18 @@ public sealed class RagConfidenceEvaluator
         Guard.Against.Null(retrievalDecision, nameof(retrievalDecision));
 
         var requiresUrgentAttention = RequiresUrgentAttention(translatedQuestionText);
+        var normalizedQuestion = RagSourceHintExtractor.Normalize(translatedQuestionText);
+        var questionTerms = RagSourceHintExtractor.TokenizeNormalized(normalizedQuestion);
         var primary = retrievalDecision.RankedDocuments.FirstOrDefault();
         var runnerUp = retrievalDecision.RankedDocuments.Skip(1).FirstOrDefault();
+        var primaryAuthorityType = primary?.AuthorityType ?? RagSourceMetadata.BindingLaw;
+        var hasBindingLawSupport = retrievalDecision.SelectedChunks.Any(chunk =>
+            chunk.AuthorityType == RagSourceMetadata.BindingLaw);
+        var hasGuidanceSupport = retrievalDecision.SelectedChunks.Any(chunk =>
+            chunk.AuthorityType == RagSourceMetadata.OfficialGuidance);
+        var guidanceOnlySupport = hasGuidanceSupport && !hasBindingLawSupport;
+        var userExplicitlyAskedForLaw = questionTerms.Any(BindingLawExpectationTerms.Contains);
+        var hasCompetingControllingSource = HasCompetingControllingSource(primary, retrievalDecision.RankedDocuments);
 
         if (primary is null || retrievalDecision.SelectedChunks.Count == 0)
         {
@@ -65,11 +80,22 @@ public sealed class RagConfidenceEvaluator
             primary.DocumentSemanticScore >= 0.60f &&
             primary.MetadataAlignmentScore >= 0.35f &&
             primary.SemanticBreadthScore >= 0.34f;
+        var supportsDirectLawAnswer =
+            primaryAuthorityType == RagSourceMetadata.BindingLaw &&
+            !hasCompetingControllingSource;
+        var supportsGuidanceOnlyAnswer =
+            guidanceOnlySupport &&
+            primary.FinalDocumentScore >= 0.70f &&
+            strongChunkCount >= 1 &&
+            !userExplicitlyAskedForLaw &&
+            !hasCompetingControllingSource &&
+            !retrievalDecision.IsAmbiguousQuestion;
 
         if (primary.FinalDocumentScore >= 0.76f &&
             strongChunkCount >= 2 &&
             scoreGap >= 0.06f &&
-            !retrievalDecision.IsAmbiguousQuestion)
+            !retrievalDecision.IsAmbiguousQuestion &&
+            supportsDirectLawAnswer)
         {
             var directDecision = retrievalDecision with
             {
@@ -87,9 +113,17 @@ public sealed class RagConfidenceEvaluator
                 : directDecision;
         }
 
-        if (primary.FinalDocumentScore >= 0.56f &&
-            (strongChunkCount >= 1 || hasBroadDocumentSupport) &&
-            !retrievalDecision.IsAmbiguousQuestion)
+        if (guidanceOnlySupport && userExplicitlyAskedForLaw)
+        {
+            return retrievalDecision with
+            {
+                AnswerMode = RagAnswerMode.Clarification,
+                ConfidenceBand = RagConfidenceBand.Low,
+                RequiresUrgentAttention = requiresUrgentAttention
+            };
+        }
+
+        if (supportsGuidanceOnlyAnswer)
         {
             return retrievalDecision with
             {
@@ -99,7 +133,20 @@ public sealed class RagConfidenceEvaluator
             };
         }
 
-        if (primary.FinalDocumentScore >= 0.46f || hasBroadDocumentSupport)
+        if (primary.FinalDocumentScore >= 0.56f &&
+            (strongChunkCount >= 1 || hasBroadDocumentSupport) &&
+            !retrievalDecision.IsAmbiguousQuestion &&
+            !hasCompetingControllingSource)
+        {
+            return retrievalDecision with
+            {
+                AnswerMode = RagAnswerMode.Cautious,
+                ConfidenceBand = RagConfidenceBand.Medium,
+                RequiresUrgentAttention = requiresUrgentAttention
+            };
+        }
+
+        if (guidanceOnlySupport || hasCompetingControllingSource || primary.FinalDocumentScore >= 0.46f || hasBroadDocumentSupport)
         {
             return retrievalDecision with
             {
@@ -115,6 +162,24 @@ public sealed class RagConfidenceEvaluator
             ConfidenceBand = RagConfidenceBand.Low,
             RequiresUrgentAttention = requiresUrgentAttention
         };
+    }
+
+    private static bool HasCompetingControllingSource(
+        DocumentCandidate primary,
+        IReadOnlyList<DocumentCandidate> rankedDocuments)
+    {
+        if (primary is null || rankedDocuments.Count < 2)
+        {
+            return false;
+        }
+
+        return rankedDocuments
+            .Skip(1)
+            .Any(candidate =>
+                !string.Equals(candidate.SourceFamily, primary.SourceFamily, StringComparison.OrdinalIgnoreCase) &&
+                candidate.FinalDocumentScore >= primary.FinalDocumentScore - 0.035f &&
+                candidate.DocumentSemanticScore >= 0.55f &&
+                candidate.MetadataAlignmentScore >= 0.22f);
     }
 
     private static bool RequiresUrgentAttention(string translatedQuestionText)

--- a/backend/src/backend.Application/Services/RagService/RagPromptBuilder.cs
+++ b/backend/src/backend.Application/Services/RagService/RagPromptBuilder.cs
@@ -54,26 +54,29 @@ public static class RagPromptBuilder
             "you MUST say that the available legislation is not enough.\n" +
             "4. Do NOT speculate, infer, or draw on general knowledge outside the provided context.\n" +
             "5. Write in plain, accessible language for the user. Avoid legal jargon where a simpler word exists.\n" +
-            "6. When both binding law and official guidance appear, present the binding law as controlling and the guidance as supporting context only.";
+            "6. When both binding law and official guidance appear, present the binding law as controlling and the guidance as supporting context only.\n" +
+            "7. If the retrieved support is official guidance only, say clearly that it is official guidance and not binding law.\n" +
+            "8. If the retrieved sources are incomplete, weak, or point in different directions, make that limit explicit and avoid a definitive legal conclusion.\n" +
+            "9. Conversation history may help you understand follow-up references like 'that' or 'they', but prior assistant messages are not legal authority.";
 
         if (answerMode == RagAnswerMode.Cautious)
         {
-            prompt += "\n7. Make the limits of the available legislation explicit before giving your grounded answer.";
+            prompt += "\n10. Make the limits of the available legislation explicit before giving your grounded answer.";
         }
 
         if (answerMode == RagAnswerMode.Clarification)
         {
-            prompt += "\n7. Ask exactly one focused follow-up question and do NOT provide a legal conclusion.";
+            prompt += "\n10. Ask exactly one focused follow-up question and do NOT provide a legal conclusion.";
         }
 
         if (requiresUrgentAttention)
         {
-            prompt += "\n8. Because the question may involve immediate harm, enforcement, or deadlines, include a short immediate-help note and avoid sounding definitive where facts are still missing.";
+            prompt += "\n11. Because the question may involve immediate harm, enforcement, or deadlines, include a short immediate-help note and avoid sounding definitive where facts are still missing.";
         }
 
         var directive = GetLanguageDirective(language);
         if (!string.IsNullOrEmpty(directive))
-            prompt += $"\n\n9. {directive}";
+            prompt += $"\n\n12. {directive}";
 
         return prompt;
     }
@@ -143,10 +146,15 @@ public static class RagPromptBuilder
         string contextBlock,
         RagAnswerMode answerMode,
         string clarificationQuestion = null,
+        string conversationHistoryBlock = null,
         bool requiresUrgentAttention = false)
     {
         Guard.Against.NullOrWhiteSpace(questionText, nameof(questionText));
         Guard.Against.Null(contextBlock, nameof(contextBlock));
+
+        var historyPrefix = string.IsNullOrWhiteSpace(conversationHistoryBlock)
+            ? string.Empty
+            : $"Conversation history for continuity only (not legal authority):\n\n{conversationHistoryBlock}\n\n";
 
         if (answerMode == RagAnswerMode.Clarification)
         {
@@ -160,15 +168,15 @@ public static class RagPromptBuilder
             }
 
             return
-                $"Legislation context:\n\n{contextBlock}\n\n" +
+                $"{historyPrefix}Legislation context:\n\n{contextBlock}\n\n" +
                 $"Original question: {questionText}\n\n" +
                 $"{guidance}\n\n" +
                 "Return only the follow-up question.";
         }
 
         var answerLead = answerMode == RagAnswerMode.Cautious
-            ? "Answer carefully, explain any limits in the available legislation, and include citations for every material claim."
-            : "Answer directly using only the legislation context and include citations for every material claim.";
+            ? "Answer carefully, identify the controlling source first, explain any limits in the available legislation, and include citations for every material claim."
+            : "Answer directly using only the legislation context, identify the controlling source first, and include citations for every material claim.";
 
         if (requiresUrgentAttention)
         {
@@ -176,7 +184,7 @@ public static class RagPromptBuilder
         }
 
         return
-            $"Legislation context:\n\n{contextBlock}\n\n" +
+            $"{historyPrefix}Legislation context:\n\n{contextBlock}\n\n" +
             $"Question: {questionText}\n\n" +
             $"{answerLead}\n\n" +
             "Answer:";

--- a/backend/src/backend.Web.Host/Controllers/QaController.cs
+++ b/backend/src/backend.Web.Host/Controllers/QaController.cs
@@ -3,6 +3,7 @@ using backend.Controllers;
 using backend.Services.RagService;
 using backend.Services.RagService.DTO;
 using Microsoft.AspNetCore.Mvc;
+using System;
 using System.Threading.Tasks;
 
 namespace backend.Web.Host.Controllers
@@ -45,6 +46,17 @@ namespace backend.Web.Host.Controllers
         public Task<ConversationsListDto> GetConversations()
         {
             return _ragAppService.GetConversationsAsync();
+        }
+
+        /// <summary>
+        /// Returns one authenticated user's full stored conversation thread, including user messages
+        /// and persisted assistant replies, so clients can render or resume the conversation.
+        /// </summary>
+        [HttpGet("conversations/{conversationId:guid}")]
+        [AbpAuthorize]
+        public Task<ConversationDetailDto> GetConversation(Guid conversationId)
+        {
+            return _ragAppService.GetConversationAsync(conversationId);
         }
     }
 }

--- a/backend/test/backend.Tests/ContractServiceTests/ContractAppServiceTests.cs
+++ b/backend/test/backend.Tests/ContractServiceTests/ContractAppServiceTests.cs
@@ -165,11 +165,17 @@ public class ContractAppServiceTests
         var result = await harness.Service.AskAsync(targetId, new AskContractQuestionRequest
         {
             QuestionText = "Can they really require three months notice?",
-            ResponseLanguageCode = "en"
+            ResponseLanguageCode = "en",
+            ConversationHistory = new List<ContractConversationHistoryMessageDto>
+            {
+                new() { Role = "user", Text = "What does the contract say about notice?" },
+                new() { Role = "assistant", Text = "It refers to three months written notice." }
+            }
         });
 
         result.AnswerMode.ShouldBe(RagAnswerMode.Cautious);
         result.ContractExcerpts.Count.ShouldBe(1);
+        harness.FollowUpService.LastConversationHistory?.Count.ShouldBe(2);
     }
 
     private sealed class ContractAppServiceHarness
@@ -329,12 +335,15 @@ public class ContractAppServiceTests
         }
 
         public ContractFollowUpAnswerDto Result { get; set; } = new();
+        public IReadOnlyList<ContractConversationHistoryMessageDto>? LastConversationHistory { get; private set; }
 
         public override Task<ContractFollowUpAnswerDto> AskAsync(
             ContractAnalysis analysis,
             string questionText,
-            string responseLanguageCode = null)
+            string responseLanguageCode = null,
+            IReadOnlyList<ContractConversationHistoryMessageDto> conversationHistory = null)
         {
+            LastConversationHistory = conversationHistory;
             return Task.FromResult(Result);
         }
     }

--- a/backend/test/backend.Tests/ContractServiceTests/ContractFollowUpServiceTests.cs
+++ b/backend/test/backend.Tests/ContractServiceTests/ContractFollowUpServiceTests.cs
@@ -60,6 +60,31 @@ public class ContractFollowUpServiceTests
     }
 
     [Fact]
+    public async Task AskAsync_WithConversationHistory_IncludesContinuityBlockInPrompt()
+    {
+        var service = new TestableContractFollowUpService(
+            BuildContext(ContractCoverageState.InCorpusNow),
+            "Can they still enforce that notice period?",
+            "This clause needs review before you rely on it. [Consumer Protection Act 68 of 2008, Section 14]");
+
+        await service.AskAsync(
+            BuildAnalysis(),
+            "Can they still enforce that notice period?",
+            "en",
+            new List<ContractConversationHistoryMessageDto>
+            {
+                new() { Role = "user", Text = "What notice period does the contract say?" },
+                new() { Role = "assistant", Text = "It mentions three calendar months in the clause excerpt." }
+            });
+
+        service.LastUserPrompt.ShouldContain("Conversation history for continuity only");
+        service.LastUserPrompt.ShouldContain("User: What notice period does the contract say?");
+        service.LastUserPrompt.ShouldContain("Assistant: It mentions three calendar months in the clause excerpt.");
+        service.LastRetrievalQuestion.ShouldContain("Current follow-up question: Can they still enforce that notice period?");
+        service.LastRetrievalQuestion.ShouldContain("User: What notice period does the contract say?");
+    }
+
+    [Fact]
     public void SelectRelevantExcerpts_PrefersQuestionAlignedLines()
     {
         var excerpts = ContractFollowUpService.SelectRelevantExcerpts(
@@ -125,25 +150,40 @@ public class ContractFollowUpServiceTests
 
     private sealed class TestableContractFollowUpService : ContractFollowUpService
     {
-        private readonly ContractLegislationContext _context;
         private readonly string _analysisResponse;
+        private readonly StubContextBuilder _contextBuilder;
 
         public TestableContractFollowUpService(
             ContractLegislationContext context,
             string translatedQuestionText,
             string analysisResponse)
-            : base(
+            : this(
                 new StubContextBuilder(context),
+                translatedQuestionText,
+                analysisResponse)
+        {
+        }
+
+        private TestableContractFollowUpService(
+            StubContextBuilder contextBuilder,
+            string translatedQuestionText,
+            string analysisResponse)
+            : base(
+                contextBuilder,
                 new StubLanguageAppService(translatedQuestionText),
                 Substitute.For<IHttpClientFactory>(),
                 BuildConfig())
         {
-            _context = context;
+            _contextBuilder = contextBuilder;
             _analysisResponse = analysisResponse;
         }
 
+        public string LastUserPrompt { get; private set; } = string.Empty;
+        public string LastRetrievalQuestion => _contextBuilder.LastFollowUpQuestion;
+
         protected override Task<string> CallChatCompletionsAsync(string systemPrompt, string userPrompt, double temperature)
         {
+            LastUserPrompt = userPrompt;
             return Task.FromResult(_analysisResponse);
         }
     }
@@ -151,6 +191,7 @@ public class ContractFollowUpServiceTests
     private sealed class StubContextBuilder : ContractLegislationContextBuilder
     {
         private readonly ContractLegislationContext _context;
+        public string LastFollowUpQuestion { get; private set; } = string.Empty;
 
         public StubContextBuilder(ContractLegislationContext context)
             : base(
@@ -166,6 +207,7 @@ public class ContractFollowUpServiceTests
             string extractedText,
             string followUpQuestion)
         {
+            LastFollowUpQuestion = followUpQuestion;
             return Task.FromResult(_context);
         }
     }

--- a/backend/test/backend.Tests/RagServiceTests/RagAppServiceTests.cs
+++ b/backend/test/backend.Tests/RagServiceTests/RagAppServiceTests.cs
@@ -50,6 +50,10 @@ public class RagAppServiceTests
         result.AnswerId.ShouldBe(harness.Service.NextAnswerId);
         result.AnswerId.ShouldNotBeNull();
         result.Citations.ShouldNotBeEmpty();
+        result.PrimarySourceTitle.ShouldBe("Constitution of the Republic of South Africa");
+        result.PrimarySourceLocator.ShouldBe("Section 26(3)");
+        result.PrimaryAuthorityType.ShouldBe(RagSourceMetadata.BindingLaw);
+        result.HasSupportingSources.ShouldBeFalse();
 
         harness.Service.PersistedQuestionCount.ShouldBe(1);
         harness.Service.PersistedAnswerCount.ShouldBe(1);
@@ -79,14 +83,18 @@ public class RagAppServiceTests
         });
 
         result.AnswerMode.ShouldBe(RagAnswerMode.Insufficient);
-        result.AnswerId.ShouldBeNull();
+        result.AnswerId.ShouldBe(harness.Service.NextAnswerId);
         result.Citations.ShouldBeEmpty();
         result.ChunkIds.ShouldBeEmpty();
         result.DetectedLanguageCode.ShouldBe("af");
+        result.PrimarySourceTitle.ShouldBeNull();
+        result.PrimarySourceLocator.ShouldBeNull();
+        result.PrimaryAuthorityType.ShouldBeNull();
+        result.HasSupportingSources.ShouldBeFalse();
 
         harness.Service.PersistedQuestionCount.ShouldBe(1);
-        harness.Service.PersistedAnswerCount.ShouldBe(0);
-        harness.Service.LastConversationId.ShouldBe(suppliedConversationId);
+        harness.Service.PersistedAnswerCount.ShouldBe(1);
+        harness.Service.LastConversationId.ShouldBeNull();
         harness.Service.LastOriginalText.ShouldBe("Kan my verhuurder my uitsit?");
         harness.Service.LastTranslatedText.ShouldBe("Can my landlord evict me without a court order?");
         harness.Service.LastQuestionLanguage.ShouldBe(Language.Afrikaans);
@@ -266,8 +274,8 @@ public class RagAppServiceTests
     {
         RagAppService.ShouldPersistAnswer(RagAnswerMode.Direct).ShouldBeTrue();
         RagAppService.ShouldPersistAnswer(RagAnswerMode.Cautious).ShouldBeTrue();
-        RagAppService.ShouldPersistAnswer(RagAnswerMode.Clarification).ShouldBeFalse();
-        RagAppService.ShouldPersistAnswer(RagAnswerMode.Insufficient).ShouldBeFalse();
+        RagAppService.ShouldPersistAnswer(RagAnswerMode.Clarification).ShouldBeTrue();
+        RagAppService.ShouldPersistAnswer(RagAnswerMode.Insufficient).ShouldBeTrue();
     }
 
     [Fact]
@@ -287,6 +295,10 @@ public class RagAppServiceTests
         result.AnswerId.ShouldBeNull();
         result.Citations.ShouldBeEmpty();
         result.ChunkIds.ShouldBeEmpty();
+        result.PrimarySourceTitle.ShouldBeNull();
+        result.PrimarySourceLocator.ShouldBeNull();
+        result.PrimaryAuthorityType.ShouldBeNull();
+        result.HasSupportingSources.ShouldBeFalse();
         result.ClarificationQuestion.ShouldBe(clarificationQuestion);
         result.AnswerText.ShouldContain("need one detail first");
     }
@@ -325,6 +337,10 @@ public class RagAppServiceTests
         result.Citations.ShouldBeEmpty();
         result.ChunkIds.ShouldBeEmpty();
         result.AnswerId.ShouldBeNull();
+        result.PrimarySourceTitle.ShouldBeNull();
+        result.PrimarySourceLocator.ShouldBeNull();
+        result.PrimaryAuthorityType.ShouldBeNull();
+        result.HasSupportingSources.ShouldBeFalse();
         result.ClarificationQuestion.ShouldBeNull();
     }
 
@@ -382,6 +398,67 @@ public class RagAppServiceTests
             citation.SourceRole == RagSourceMetadata.Supporting);
     }
 
+    [Fact]
+    public async Task AskAsync_WithExistingConversation_UsesStoredTurnsAsPromptContext()
+    {
+        var harness = CreateHarness(
+            CreateGroundedHousingChunks(),
+            new float[] { 1f, 0f },
+            Language.English,
+            "What if they change the locks?",
+            "A landlord still cannot evict you without a court order.");
+        var suppliedConversationId = Guid.Parse("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+        harness.SeedConversationThread(
+            suppliedConversationId,
+            42,
+            DateTime.UtcNow.AddMinutes(-10),
+            ("Can my landlord evict me without a court order?", "No. A court order is required."));
+        harness.Service.UseSession(42);
+        harness.Service.UseBaseQuestionPersistence = true;
+
+        await harness.Service.AskAsync(new AskQuestionRequest
+        {
+            QuestionText = "What if they change the locks?",
+            ConversationId = suppliedConversationId
+        });
+
+        harness.LastChatRequestBody.ShouldContain("Conversation history for continuity only");
+        harness.LastChatRequestBody.ShouldContain("User: Can my landlord evict me without a court order?");
+        harness.LastChatRequestBody.ShouldContain("Assistant: No. A court order is required.");
+        harness.EmbeddingRequests.ShouldContain(request =>
+            request.Contains("Current question: What if they change the locks?", StringComparison.Ordinal));
+        harness.EmbeddingRequests.ShouldContain(request =>
+            request.Contains("User: Can my landlord evict me without a court order?", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task GetConversationAsync_ReturnsOrderedUserAndAssistantMessages()
+    {
+        var harness = CreateHarness(
+            CreateGroundedHousingChunks(),
+            new float[] { 1f, 0f },
+            Language.English,
+            "unused",
+            "unused");
+        var conversationId = Guid.Parse("ffffffff-ffff-ffff-ffff-ffffffffffff");
+        harness.SeedConversationThread(
+            conversationId,
+            42,
+            DateTime.UtcNow.AddMinutes(-10),
+            ("Can my landlord evict me without a court order?", "No. A court order is required."),
+            ("What if they change the locks?", "That still needs a court process."));
+        harness.Service.UseSession(42);
+
+        var result = await harness.Service.GetConversationAsync(conversationId);
+
+        result.ConversationId.ShouldBe(conversationId);
+        result.QuestionCount.ShouldBe(2);
+        result.Messages.Select(message => message.Type).ShouldBe(new[] { "user", "bot", "user", "bot" });
+        result.Messages[0].Text.ShouldBe("Can my landlord evict me without a court order?");
+        result.Messages[1].Text.ShouldBe("No. A court order is required.");
+        result.Messages[2].Text.ShouldBe("What if they change the locks?");
+    }
+
     private static RagAppServiceHarness CreateHarness(
         IReadOnlyList<IndexedChunk> loadedChunks,
         float[] questionVector,
@@ -393,19 +470,26 @@ public class RagAppServiceTests
         store.Replace(loadedChunks, new RagDocumentProfileBuilder().Build(loadedChunks).ToList());
 
         var embeddingService = Substitute.For<IEmbeddingAppService>();
-        embeddingService.GenerateEmbeddingAsync(Arg.Any<string>()).Returns(_ => new EmbeddingResult
+        var embeddingRequests = new List<string>();
+        embeddingService.GenerateEmbeddingAsync(Arg.Any<string>()).Returns(call =>
         {
-            Vector = questionVector,
-            Model = "text-embedding-3-small",
-            InputCharacterCount = translatedText.Length
+            var text = call.Arg<string>();
+            embeddingRequests.Add(text);
+            return new EmbeddingResult
+            {
+                Vector = questionVector,
+                Model = "text-embedding-3-small",
+                InputCharacterCount = text.Length
+            };
         });
 
         var languageService = Substitute.For<ILanguageAppService>();
         languageService.DetectLanguageAsync(Arg.Any<string>()).Returns(detectedLanguage);
         languageService.TranslateToEnglishAsync(Arg.Any<string>(), detectedLanguage).Returns(translatedText);
 
+        var chatHandler = new StubChatHandler(chatResponse);
         var httpFactory = Substitute.For<IHttpClientFactory>();
-        httpFactory.CreateClient("OpenAI").Returns(_ => new HttpClient(new StubChatHandler(chatResponse))
+        httpFactory.CreateClient("OpenAI").Returns(_ => new HttpClient(chatHandler)
         {
             BaseAddress = new Uri("https://api.openai.com/")
         });
@@ -415,7 +499,9 @@ public class RagAppServiceTests
             languageService,
             store,
             httpFactory,
-            BuildConfig());
+            BuildConfig(),
+            chatHandler,
+            embeddingRequests);
     }
 
     private static IConfiguration BuildConfig()
@@ -516,6 +602,7 @@ public class RagAppServiceTests
     private sealed class StubChatHandler : HttpMessageHandler
     {
         private readonly string _content;
+        public string LastRequestBody { get; private set; } = string.Empty;
 
         public StubChatHandler(string content)
         {
@@ -526,6 +613,10 @@ public class RagAppServiceTests
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            LastRequestBody = request.Content is null
+                ? string.Empty
+                : request.Content.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult();
+
             var payload = JsonSerializer.Serialize(new
             {
                 choices = new[]
@@ -557,14 +648,22 @@ public class RagAppServiceTests
         public List<Answer> Answers { get; } = new();
         public List<AnswerCitation> Citations { get; } = new();
         public TestableRagAppService Service { get; }
+        public string LastChatRequestBody => _chatHandler.LastRequestBody;
+        public IReadOnlyList<string> EmbeddingRequests => _embeddingRequests;
+        private readonly StubChatHandler _chatHandler;
+        private readonly List<string> _embeddingRequests;
 
         public RagAppServiceHarness(
             IEmbeddingAppService embeddingService,
             ILanguageAppService languageService,
             RagIndexStore ragIndexStore,
             IHttpClientFactory httpClientFactory,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            StubChatHandler chatHandler,
+            List<string> embeddingRequests)
         {
+            _chatHandler = chatHandler;
+            _embeddingRequests = embeddingRequests;
             var conversationRepository = Substitute.For<IRepository<Conversation, Guid>>();
             var questionRepository = Substitute.For<IRepository<Question, Guid>>();
             var answerRepository = Substitute.For<IRepository<Answer, Guid>>();
@@ -631,7 +730,8 @@ public class RagAppServiceTests
                 citationRepository,
                 ragIndexStore,
                 httpClientFactory,
-                configuration);
+                configuration,
+                Conversations);
         }
 
         public Conversation SeedConversation(
@@ -662,10 +762,58 @@ public class RagAppServiceTests
             Conversations.Add(conversation);
             return conversation;
         }
+
+        public Conversation SeedConversationThread(
+            Guid conversationId,
+            long userId,
+            DateTime startedAt,
+            params (string Question, string Answer)[] turns)
+        {
+            var conversation = new Conversation
+            {
+                Id = conversationId,
+                UserId = userId,
+                Language = Language.English,
+                InputMethod = InputMethod.Text,
+                StartedAt = startedAt,
+                Questions = turns.Select((turn, index) =>
+                {
+                    var questionTime = startedAt.AddMinutes(index * 2);
+                    var questionId = Guid.NewGuid();
+                    return new Question
+                    {
+                        Id = questionId,
+                        ConversationId = conversationId,
+                        OriginalText = turn.Question,
+                        TranslatedText = turn.Question,
+                        Language = Language.English,
+                        InputMethod = InputMethod.Text,
+                        CreationTime = questionTime,
+                        Answers = new List<Answer>
+                        {
+                            new()
+                            {
+                                Id = Guid.NewGuid(),
+                                QuestionId = questionId,
+                                Text = turn.Answer,
+                                Language = Language.English,
+                                CreationTime = questionTime.AddSeconds(30),
+                                Citations = new List<AnswerCitation>()
+                            }
+                        }
+                    };
+                }).ToList()
+            };
+
+            Conversations.Add(conversation);
+            return conversation;
+        }
     }
 
     private sealed class TestableRagAppService : RagAppService
     {
+        private readonly List<Conversation> _conversations;
+
         public TestableRagAppService(
             IEmbeddingAppService embeddingService,
             ILanguageAppService languageService,
@@ -676,7 +824,8 @@ public class RagAppServiceTests
             IRepository<AnswerCitation, Guid> citationRepository,
             RagIndexStore ragIndexStore,
             IHttpClientFactory httpClientFactory,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            List<Conversation> conversations)
             : base(
                 embeddingService,
                 languageService,
@@ -689,6 +838,7 @@ public class RagAppServiceTests
                 httpClientFactory,
                 configuration)
         {
+            _conversations = conversations;
         }
 
         public Guid NextQuestionId { get; } = Guid.Parse("11111111-1111-1111-1111-111111111111");
@@ -751,6 +901,14 @@ public class RagAppServiceTests
         protected override Task<List<Conversation>> ListConversationsAsync(IOrderedQueryable<Conversation> query)
         {
             return Task.FromResult(query.ToList());
+        }
+
+        protected override Task<Conversation> LoadConversationThreadAsync(long userId, Guid conversationId)
+        {
+            return Task.FromResult(
+                _conversations.FirstOrDefault(conversation =>
+                    conversation.Id == conversationId &&
+                    conversation.UserId == userId))!;
         }
     }
 }

--- a/backend/test/backend.Tests/RagServiceTests/RagConfidenceEvaluatorTests.cs
+++ b/backend/test/backend.Tests/RagServiceTests/RagConfidenceEvaluatorTests.cs
@@ -129,6 +129,55 @@ public class RagConfidenceEvaluatorTests
         result.RequiresUrgentAttention.ShouldBeTrue();
     }
 
+    [Fact]
+    public void Evaluate_GuidanceOnlySupport_DoesNotReturnDirect()
+    {
+        var decision = CreateDecision(
+            primaryScore: 0.83f,
+            runnerUpScore: 0.45f,
+            chunkScores: new[] { 0.86f, 0.79f },
+            isAmbiguous: false,
+            primaryAuthorityType: RagSourceMetadata.OfficialGuidance,
+            selectedChunkAuthorityType: RagSourceMetadata.OfficialGuidance);
+
+        var result = _evaluator.Evaluate("How do I complain to the tribunal?", decision);
+
+        result.AnswerMode.ShouldBe(RagAnswerMode.Cautious);
+        result.ConfidenceBand.ShouldBe(RagConfidenceBand.Medium);
+    }
+
+    [Fact]
+    public void Evaluate_GuidanceOnlySupport_WhenUserAsksForLaw_ReturnsClarification()
+    {
+        var decision = CreateDecision(
+            primaryScore: 0.83f,
+            runnerUpScore: 0.45f,
+            chunkScores: new[] { 0.86f, 0.79f },
+            isAmbiguous: false,
+            primaryAuthorityType: RagSourceMetadata.OfficialGuidance,
+            selectedChunkAuthorityType: RagSourceMetadata.OfficialGuidance);
+
+        var result = _evaluator.Evaluate("What law says I can complain to the tribunal?", decision);
+
+        result.AnswerMode.ShouldBe(RagAnswerMode.Clarification);
+        result.ConfidenceBand.ShouldBe(RagConfidenceBand.Low);
+    }
+
+    [Fact]
+    public void Evaluate_CloseCompetingSources_DowngradesToClarification()
+    {
+        var decision = CreateDecision(
+            primaryScore: 0.79f,
+            runnerUpScore: 0.765f,
+            chunkScores: new[] { 0.88f, 0.81f },
+            isAmbiguous: false);
+
+        var result = _evaluator.Evaluate("Which law controls this rental dispute?", decision);
+
+        result.AnswerMode.ShouldBe(RagAnswerMode.Clarification);
+        result.ConfidenceBand.ShouldBe(RagConfidenceBand.Low);
+    }
+
     private static RetrievalDecision CreateDecision(
         float primaryScore,
         float runnerUpScore,
@@ -136,7 +185,10 @@ public class RagConfidenceEvaluatorTests
         bool isAmbiguous,
         float documentSemanticScore = 0.70f,
         float metadataAlignmentScore = 0.40f,
-        float semanticBreadthScore = 0.50f)
+        float semanticBreadthScore = 0.50f,
+        string primaryAuthorityType = RagSourceMetadata.BindingLaw,
+        string runnerUpAuthorityType = RagSourceMetadata.BindingLaw,
+        string selectedChunkAuthorityType = RagSourceMetadata.BindingLaw)
     {
         var primaryDocId = Guid.NewGuid();
         var runnerUpDocId = Guid.NewGuid();
@@ -157,7 +209,11 @@ public class RagConfidenceEvaluatorTests
                     Array.Empty<string>(),
                     score,
                     score,
-                    32))
+                    32,
+                    "Constitution of the Republic of South Africa",
+                    "Section 26(3)",
+                    selectedChunkAuthorityType,
+                    RagSourceMetadata.Primary))
                 .ToList(),
             RankedDocuments = new[]
             {
@@ -173,7 +229,9 @@ public class RagConfidenceEvaluatorTests
                     metadataAlignmentScore,
                     semanticBreadthScore,
                     0f,
-                    primaryScore),
+                    primaryScore,
+                    primaryAuthorityType,
+                    "constitution"),
                 new DocumentCandidate(
                     runnerUpDocId,
                     "Rental Housing Act 50 of 1999",
@@ -186,7 +244,9 @@ public class RagConfidenceEvaluatorTests
                     0.25f,
                     0.25f,
                     0f,
-                    runnerUpScore)
+                    runnerUpScore,
+                    runnerUpAuthorityType,
+                    "rental housing act")
             },
             ClarificationQuestion = "Can you share whether this is about a rented home?",
             IsAmbiguousQuestion = isAmbiguous

--- a/backend/test/backend.Tests/RagServiceTests/RagPromptBuilderTests.cs
+++ b/backend/test/backend.Tests/RagServiceTests/RagPromptBuilderTests.cs
@@ -46,6 +46,8 @@ public class RagPromptBuilderTests
 
         result.ShouldContain("binding law as controlling");
         result.ShouldContain("immediate-help note");
+        result.ShouldContain("official guidance and not binding law");
+        result.ShouldContain("point in different directions");
     }
 
     [Fact]
@@ -91,6 +93,30 @@ public class RagPromptBuilderTests
 
         result.ShouldContain("Return only the follow-up question.");
         result.ShouldContain("Can you share whether this is about a rented home?");
+    }
+
+    [Fact]
+    public void BuildUserPrompt_ForDirectMode_AsksModelToIdentifyControllingSource()
+    {
+        var result = RagPromptBuilder.BuildUserPrompt(
+            "Can my landlord evict me?",
+            "[Act - Section]\nContext",
+            RagAnswerMode.Direct);
+
+        result.ShouldContain("identify the controlling source first");
+    }
+
+    [Fact]
+    public void BuildUserPrompt_WithConversationHistory_IncludesContinuityBlock()
+    {
+        var result = RagPromptBuilder.BuildUserPrompt(
+            "What if they change the locks?",
+            "[Act - Section]\nContext",
+            RagAnswerMode.Cautious,
+            conversationHistoryBlock: "User: Can my landlord evict me?\nAssistant: A court order is required.");
+
+        result.ShouldContain("Conversation history for continuity only");
+        result.ShouldContain("A court order is required.");
     }
 
     [Fact]

--- a/frontend/src/app/[locale]/contracts/[id]/page.tsx
+++ b/frontend/src/app/[locale]/contracts/[id]/page.tsx
@@ -20,6 +20,7 @@ import {
   useContractsState,
 } from "@/providers/contracts-provider";
 import {
+  type ContractConversationMessage,
   formatContractDate,
   getContractTypeLabel,
   getContractVerdict,
@@ -41,6 +42,45 @@ type FollowUpMessage =
       text: string;
       answer: ContractFollowUpAnswer;
     };
+
+const CONTRACT_CHAT_STORAGE_PREFIX = "mzansi-legal-contract-chat:";
+
+function getContractChatStorageKey(id: string) {
+  return `${CONTRACT_CHAT_STORAGE_PREFIX}${id}`;
+}
+
+function toConversationHistory(messages: FollowUpMessage[]): ContractConversationMessage[] {
+  return messages.map((message) => ({
+    role: message.role,
+    text: message.text,
+  }));
+}
+
+function loadStoredConversation(id: string): FollowUpMessage[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const raw = window.localStorage.getItem(getContractChatStorageKey(id));
+    if (!raw) {
+      return [];
+    }
+
+    const parsed = JSON.parse(raw) as FollowUpMessage[];
+    return Array.isArray(parsed)
+      ? parsed.filter(
+          (message) =>
+            message &&
+            (message.role === "user" || message.role === "assistant") &&
+            typeof message.text === "string",
+        )
+      : [];
+  } catch {
+    window.localStorage.removeItem(getContractChatStorageKey(id));
+    return [];
+  }
+}
 
 function getVerdictTone(verdict: "good" | "review" | "high-risk") {
   switch (verdict) {
@@ -158,6 +198,28 @@ function ContractDetailContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, locale]);
 
+  useEffect(() => {
+    if (!id) {
+      return;
+    }
+
+    setFollowUpMessages(loadStoredConversation(id));
+  }, [id]);
+
+  useEffect(() => {
+    if (!id || typeof window === "undefined") {
+      return;
+    }
+
+    const storageKey = getContractChatStorageKey(id);
+    if (followUpMessages.length === 0) {
+      window.localStorage.removeItem(storageKey);
+      return;
+    }
+
+    window.localStorage.setItem(storageKey, JSON.stringify(followUpMessages));
+  }, [followUpMessages, id]);
+
   if (isPending && !selected) {
     return (
       <main
@@ -237,16 +299,25 @@ function ContractDetailContent() {
       return;
     }
 
+    const userMessage: FollowUpMessage = {
+      id: `user-${Date.now()}`,
+      role: "user",
+      text: nextQuestion,
+    };
+
     setFollowUpQuestion("");
     setFollowUpError(null);
     setIsFollowUpPending(true);
-    setFollowUpMessages((current) => [
-      ...current,
-      { id: `user-${Date.now()}`, role: "user", text: nextQuestion },
-    ]);
+    const nextHistory = [...followUpMessages, userMessage];
+    setFollowUpMessages(nextHistory);
 
     try {
-      const answer = await askContractQuestion(id, nextQuestion, locale);
+      const answer = await askContractQuestion(
+        id,
+        nextQuestion,
+        locale,
+        toConversationHistory(nextHistory),
+      );
       setFollowUpMessages((current) => [
         ...current,
         {
@@ -257,6 +328,10 @@ function ContractDetailContent() {
         },
       ]);
     } catch (error) {
+      setFollowUpMessages((current) =>
+        current.filter((message) => message.id !== userMessage.id),
+      );
+      setFollowUpQuestion(nextQuestion);
       setFollowUpError(getUserFacingErrorMessage(error, t("followUpError")));
     } finally {
       setIsFollowUpPending(false);

--- a/frontend/src/app/[locale]/history/page.tsx
+++ b/frontend/src/app/[locale]/history/page.tsx
@@ -65,7 +65,7 @@ function HistoryContent() {
               boxShadow: shadowOrganic,
             }}
           >
-            <Skeleton active paragraph={{ rows: 2 }} title={{ width: "70%" }} />
+            <Skeleton active paragraph={{ rows: 5 }} title={{ width: "70%" }} />
           </section>
         ))}
       </main>
@@ -103,7 +103,6 @@ function HistoryContent() {
           fontFamily: fontSans,
         }}
       >
-        {/* Page header */}
         <section
           style={{
             display: "flex",
@@ -152,7 +151,6 @@ function HistoryContent() {
         </section>
 
         {items.length === 0 ? (
-          /* Empty state */
           <section
             style={{
               display: "flex",
@@ -212,7 +210,6 @@ function HistoryContent() {
             </Link>
           </section>
         ) : (
-          /* Conversation list */
           <section
             style={{ display: "flex", flexDirection: "column", gap: 16 }}
           >
@@ -226,123 +223,155 @@ function HistoryContent() {
               );
 
               return (
-                <Link
+                <div
                   key={item.conversationId}
-                  href={href}
+                  className="grain-panel"
                   style={{
                     display: "flex",
-                    alignItems: "center",
+                    flexDirection: "column",
                     gap: 20,
                     padding: "24px 28px",
                     background: C.card,
                     border: `1px solid ${C.border}`,
                     borderRadius: r,
-                    boxShadow: "0 1px 4px rgba(0,0,0,0.04)",
-                    textDecoration: "none",
-                    transition: "box-shadow 0.18s ease, transform 0.18s ease",
-                  }}
-                  onMouseEnter={(e) => {
-                    e.currentTarget.style.boxShadow = shadowOrganic;
-                    e.currentTarget.style.transform = "translateY(-2px)";
-                  }}
-                  onMouseLeave={(e) => {
-                    e.currentTarget.style.boxShadow =
-                      "0 1px 4px rgba(0,0,0,0.04)";
-                    e.currentTarget.style.transform = "translateY(0)";
+                    boxShadow: shadowOrganic,
                   }}
                 >
-                  {/* Icon */}
-                  <div
+                  <Link
+                    href={href}
                     style={{
-                      width: 48,
-                      height: 48,
-                      borderRadius: 9999,
-                      background: `rgba(74,90,58,0.1)`,
                       display: "flex",
                       alignItems: "center",
-                      justifyContent: "center",
-                      color: C.primary,
-                      flexShrink: 0,
+                      gap: 20,
+                      textDecoration: "none",
                     }}
                   >
-                    <MessageSquare size={22} />
-                  </div>
-
-                  {/* Content */}
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <p
-                      style={{
-                        fontSize: 16,
-                        fontWeight: 600,
-                        color: C.fg,
-                        margin: "0 0 6px",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      {item.firstQuestion.length > 120
-                        ? `${item.firstQuestion.slice(0, 120)}…`
-                        : item.firstQuestion}
-                    </p>
                     <div
                       style={{
+                        width: 48,
+                        height: 48,
+                        borderRadius: 9999,
+                        background: `rgba(74,90,58,0.1)`,
                         display: "flex",
                         alignItems: "center",
-                        gap: 16,
-                        flexWrap: "wrap",
+                        justifyContent: "center",
+                        color: C.primary,
+                        flexShrink: 0,
                       }}
                     >
-                      <span
+                      <MessageSquare size={22} />
+                    </div>
+
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <p
+                        style={{
+                          fontSize: 16,
+                          fontWeight: 600,
+                          color: C.fg,
+                          margin: "0 0 6px",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {item.firstQuestion.length > 120
+                          ? `${item.firstQuestion.slice(0, 120)}...`
+                          : item.firstQuestion}
+                      </p>
+                      <div
                         style={{
                           display: "flex",
                           alignItems: "center",
-                          gap: 4,
-                          fontSize: 13,
-                          color: C.mutedFg,
-                          fontWeight: 500,
+                          gap: 16,
+                          flexWrap: "wrap",
                         }}
                       >
-                        <Clock size={13} />
-                        {formatDate(item.startedAt, locale)}
-                      </span>
-                      <span
-                        style={{
-                          padding: "2px 10px",
-                          borderRadius: 9999,
-                          background: C.muted,
-                          color: C.mutedFg,
-                          fontSize: 12,
-                          fontWeight: 700,
-                        }}
-                      >
-                        {item.questionCount}{" "}
-                        {item.questionCount === 1 ? "question" : "questions"}
-                      </span>
-                      {item.locale !== "en" && (
+                        <span
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 4,
+                            fontSize: 13,
+                            color: C.mutedFg,
+                            fontWeight: 500,
+                          }}
+                        >
+                          <Clock size={13} />
+                          {formatDate(item.startedAt, locale)}
+                        </span>
                         <span
                           style={{
                             padding: "2px 10px",
                             borderRadius: 9999,
-                            background: `rgba(74,90,58,0.08)`,
-                            color: C.primary,
+                            background: C.muted,
+                            color: C.mutedFg,
                             fontSize: 12,
                             fontWeight: 700,
                           }}
                         >
-                          {LOCALE_NAMES[item.locale] ?? item.locale}
+                          {item.questionCount}{" "}
+                          {item.questionCount === 1 ? "question" : "questions"}
                         </span>
-                      )}
+                        {item.locale !== "en" && (
+                          <span
+                            style={{
+                              padding: "2px 10px",
+                              borderRadius: 9999,
+                              background: `rgba(74,90,58,0.08)`,
+                              color: C.primary,
+                              fontSize: 12,
+                              fontWeight: 700,
+                            }}
+                          >
+                            {LOCALE_NAMES[item.locale] ?? item.locale}
+                          </span>
+                        )}
+                      </div>
                     </div>
-                  </div>
 
-                  {/* Arrow */}
-                  <ChevronRight
-                    size={20}
-                    color={C.mutedFg}
-                    style={{ flexShrink: 0 }}
-                  />
-                </Link>
+                    <ChevronRight
+                      size={20}
+                      color={C.mutedFg}
+                      style={{ flexShrink: 0 }}
+                    />
+                  </Link>
+
+                  {item.messages.length > 0 && (
+                    <div
+                      style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 12,
+                      }}
+                    >
+                      {item.messages.map((message) => (
+                        <div
+                          key={message.messageId}
+                          style={{
+                            alignSelf:
+                              message.type === "user"
+                                ? "flex-end"
+                                : "flex-start",
+                            maxWidth: "min(85%, 680px)",
+                            padding: "14px 18px",
+                            borderRadius: 18,
+                            background:
+                              message.type === "user" ? C.primary : C.muted,
+                            color:
+                              message.type === "user"
+                                ? C.primaryFg
+                                : C.fg,
+                            fontFamily: fontSans,
+                            lineHeight: 1.6,
+                            whiteSpace: "pre-wrap",
+                          }}
+                        >
+                          {message.text}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
               );
             })}
           </section>

--- a/frontend/src/components/chat/QaChatPage.tsx
+++ b/frontend/src/components/chat/QaChatPage.tsx
@@ -13,18 +13,53 @@ export default function QaChatPage() {
   const t = useTranslations("chat");
   const searchParams = useSearchParams();
   const initialQuestion = searchParams.get("q") ?? "";
+  const requestedConversationId = searchParams.get("conversationId");
   const lastAutoSentQuestionRef = useRef<string | null>(null);
+  const lastLoadedConversationRef = useRef<string | null>(null);
 
-  const { messages, isPending: isLoading, error } = useChatState();
-  const { sendMessage } = useChatAction();
+  const {
+    messages,
+    isPending: isLoading,
+    error,
+    conversationId,
+  } = useChatState();
+  const { sendMessage, loadConversation } = useChatAction();
   const autoSendQuestion = useEffectEvent((question: string) => {
     void sendMessage(question, locale);
   });
+  const hydrateConversation = useEffectEvent((nextConversationId: string) => {
+    void loadConversation(nextConversationId);
+  });
+
+  useEffect(() => {
+    const trimmedConversationId = requestedConversationId?.trim();
+
+    if (!trimmedConversationId) {
+      return;
+    }
+
+    if (
+      lastLoadedConversationRef.current === trimmedConversationId &&
+      conversationId === trimmedConversationId
+    ) {
+      return;
+    }
+
+    lastLoadedConversationRef.current = trimmedConversationId;
+    hydrateConversation(trimmedConversationId);
+  }, [conversationId, requestedConversationId]);
 
   useEffect(() => {
     const trimmedQuestion = initialQuestion.trim();
 
     if (!trimmedQuestion) {
+      return;
+    }
+
+    if (
+      requestedConversationId?.trim() &&
+      conversationId !== requestedConversationId.trim()
+    ) {
       return;
     }
 
@@ -34,7 +69,7 @@ export default function QaChatPage() {
 
     lastAutoSentQuestionRef.current = trimmedQuestion;
     autoSendQuestion(trimmedQuestion);
-  }, [initialQuestion]);
+  }, [conversationId, initialQuestion, requestedConversationId]);
 
   const handleSend = (text: string) => {
     // Allow guests to chat, no redirect

--- a/frontend/src/components/contracts/contractData.ts
+++ b/frontend/src/components/contracts/contractData.ts
@@ -38,6 +38,11 @@ export interface ContractFollowUpCitation {
   excerpt: string;
 }
 
+export interface ContractConversationMessage {
+  role: "user" | "assistant";
+  text: string;
+}
+
 export interface ContractFollowUpAnswer {
   answerText: string;
   answerMode: ContractAnswerMode;

--- a/frontend/src/providers/chat-provider/actions.tsx
+++ b/frontend/src/providers/chat-provider/actions.tsx
@@ -1,56 +1,20 @@
-import type { IChatStateContext, IChatMessage } from "./context";
+import type { IChatMessage } from "./context";
 
 export enum ChatStateEnums {
+  CHAT_LOAD_PENDING = "CHAT_LOAD_PENDING",
+  CHAT_LOAD_SUCCESS = "CHAT_LOAD_SUCCESS",
+  CHAT_LOAD_ERROR   = "CHAT_LOAD_ERROR",
   CHAT_SEND_PENDING = "CHAT_SEND_PENDING",
   CHAT_SEND_SUCCESS = "CHAT_SEND_SUCCESS",
   CHAT_SEND_ERROR   = "CHAT_SEND_ERROR",
-  CHAT_ADD_USER_MSG = "CHAT_ADD_USER_MSG",
   CHAT_CLEAR        = "CHAT_CLEAR",
 }
 
-export interface IChatAction {
-  type: ChatStateEnums;
-  payload: Partial<IChatStateContext>;
-}
-
-export const chatSendPending = (userMsg: IChatMessage): IChatAction => ({
-  type: ChatStateEnums.CHAT_SEND_PENDING,
-  payload: { isPending: true, isSuccess: false, isError: false, error: null, messages: undefined },
-});
-
-export const chatSendSuccess = (botMsg: IChatMessage): IChatAction => ({
-  type: ChatStateEnums.CHAT_SEND_SUCCESS,
-  payload: { isPending: false, isSuccess: true, isError: false, error: null },
-});
-
-export const chatSendError = (error: string): IChatAction => ({
-  type: ChatStateEnums.CHAT_SEND_ERROR,
-  payload: { isPending: false, isSuccess: false, isError: true, error },
-});
-
-export const chatClear = (): IChatAction => ({
-  type: ChatStateEnums.CHAT_CLEAR,
-  payload: { isPending: false, isSuccess: false, isError: false, messages: [], error: null },
-});
-
-// Carry message data alongside action for reducer use
-export interface IChatSendPendingAction extends IChatAction {
-  type: ChatStateEnums.CHAT_SEND_PENDING;
-  userMsg: IChatMessage;
-}
-
-export interface IChatSendSuccessAction extends IChatAction {
-  type: ChatStateEnums.CHAT_SEND_SUCCESS;
-  botMsg: IChatMessage;
-}
-
-export interface IChatSendErrorAction extends IChatAction {
-  type: ChatStateEnums.CHAT_SEND_ERROR;
-  errorMsg: IChatMessage;
-}
-
 export type ChatAction =
+  | { type: ChatStateEnums.CHAT_LOAD_PENDING }
+  | { type: ChatStateEnums.CHAT_LOAD_SUCCESS; messages: IChatMessage[]; conversationId: string | null }
+  | { type: ChatStateEnums.CHAT_LOAD_ERROR; error: string }
   | { type: ChatStateEnums.CHAT_SEND_PENDING; userMsg: IChatMessage }
-  | { type: ChatStateEnums.CHAT_SEND_SUCCESS; botMsg: IChatMessage }
+  | { type: ChatStateEnums.CHAT_SEND_SUCCESS; botMsg: IChatMessage; conversationId: string | null }
   | { type: ChatStateEnums.CHAT_SEND_ERROR;   errorMsg: IChatMessage; error: string }
   | { type: ChatStateEnums.CHAT_CLEAR };

--- a/frontend/src/providers/chat-provider/context.tsx
+++ b/frontend/src/providers/chat-provider/context.tsx
@@ -26,10 +26,12 @@ export interface IChatStateContext {
   isError: boolean;
   messages: IChatMessage[];
   error: string | null;
+  conversationId: string | null;
 }
 
 export interface IChatActionContext {
   sendMessage: (text: string, locale?: string) => void;
+  loadConversation: (conversationId: string) => void;
   clearMessages: () => void;
 }
 
@@ -39,10 +41,12 @@ export const INITIAL_STATE: IChatStateContext = {
   isError: false,
   messages: [],
   error: null,
+  conversationId: null,
 };
 
 export const ChatStateContext = createContext<IChatStateContext>(INITIAL_STATE);
 export const ChatActionContext = createContext<IChatActionContext>({
   sendMessage: () => {},
+  loadConversation: () => {},
   clearMessages: () => {},
 });

--- a/frontend/src/providers/chat-provider/index.tsx
+++ b/frontend/src/providers/chat-provider/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useContext, useReducer } from "react";
 import { getUserFacingErrorMessage } from "@/lib/userFacingErrors";
-import { askRagQuestion } from "@/services/qa.service";
+import { askRagQuestion, getConversation } from "@/services/qa.service";
 import { ChatReducer } from "./reducer";
 import { INITIAL_STATE, ChatStateContext, ChatActionContext } from "./context";
 import { ChatStateEnums } from "./actions";
@@ -24,7 +24,13 @@ export const ChatProvider = ({ children }: { children: React.ReactNode }) => {
     dispatch({ type: ChatStateEnums.CHAT_SEND_PENDING, userMsg });
 
     try {
-      const result = await askRagQuestion({ questionText: trimmed }, locale);
+      const result = await askRagQuestion(
+        {
+          questionText: trimmed,
+          conversationId: state.conversationId ?? undefined,
+        },
+        locale,
+      );
 
       // Validate the result structure
       if (!result || typeof result !== "object") {
@@ -45,7 +51,11 @@ export const ChatProvider = ({ children }: { children: React.ReactNode }) => {
         requiresUrgentAttention: result.requiresUrgentAttention,
       };
 
-      dispatch({ type: ChatStateEnums.CHAT_SEND_SUCCESS, botMsg });
+      dispatch({
+        type: ChatStateEnums.CHAT_SEND_SUCCESS,
+        botMsg,
+        conversationId: result.conversationId ?? state.conversationId ?? null,
+      });
     } catch (err) {
       console.error("Chat error:", err);
       const error = getUserFacingErrorMessage(
@@ -62,13 +72,46 @@ export const ChatProvider = ({ children }: { children: React.ReactNode }) => {
     }
   };
 
+  const loadConversation = async (conversationId: string) => {
+    if (!conversationId) return;
+
+    dispatch({ type: ChatStateEnums.CHAT_LOAD_PENDING });
+
+    try {
+      const conversation = await getConversation(conversationId);
+      const messages: IChatMessage[] = conversation.messages.map((message) => ({
+        id: message.messageId,
+        type: message.type === "bot" ? "bot" : "user",
+        text: message.text,
+        status: "sent",
+        detectedLanguageCode: message.detectedLanguageCode,
+        citations: message.citations,
+      }));
+
+      dispatch({
+        type: ChatStateEnums.CHAT_LOAD_SUCCESS,
+        messages,
+        conversationId: conversation.conversationId,
+      });
+    } catch (err) {
+      const error = getUserFacingErrorMessage(
+        err,
+        "We couldn't load that conversation just now. Please try again.",
+      );
+
+      dispatch({ type: ChatStateEnums.CHAT_LOAD_ERROR, error });
+    }
+  };
+
   const clearMessages = () => {
     dispatch({ type: ChatStateEnums.CHAT_CLEAR });
   };
 
   return (
     <ChatStateContext.Provider value={state}>
-      <ChatActionContext.Provider value={{ sendMessage, clearMessages }}>
+      <ChatActionContext.Provider
+        value={{ sendMessage, loadConversation, clearMessages }}
+      >
         {children}
       </ChatActionContext.Provider>
     </ChatStateContext.Provider>

--- a/frontend/src/providers/chat-provider/reducer.tsx
+++ b/frontend/src/providers/chat-provider/reducer.tsx
@@ -3,6 +3,32 @@ import { ChatStateEnums, type ChatAction } from "./actions";
 
 export function ChatReducer(state: IChatStateContext, action: ChatAction): IChatStateContext {
   switch (action.type) {
+    case ChatStateEnums.CHAT_LOAD_PENDING:
+      return {
+        ...state,
+        isPending: true,
+        isSuccess: false,
+        isError: false,
+        error: null,
+      };
+    case ChatStateEnums.CHAT_LOAD_SUCCESS:
+      return {
+        ...state,
+        isPending: false,
+        isSuccess: true,
+        isError: false,
+        error: null,
+        messages: action.messages,
+        conversationId: action.conversationId,
+      };
+    case ChatStateEnums.CHAT_LOAD_ERROR:
+      return {
+        ...state,
+        isPending: false,
+        isSuccess: false,
+        isError: true,
+        error: action.error,
+      };
     case ChatStateEnums.CHAT_SEND_PENDING:
       return {
         ...state,
@@ -19,6 +45,7 @@ export function ChatReducer(state: IChatStateContext, action: ChatAction): IChat
         isSuccess: true,
         isError: false,
         messages: [...state.messages, action.botMsg],
+        conversationId: action.conversationId,
       };
     case ChatStateEnums.CHAT_SEND_ERROR:
       return {

--- a/frontend/src/providers/history-provider/context.tsx
+++ b/frontend/src/providers/history-provider/context.tsx
@@ -7,6 +7,12 @@ export interface IConversationItem {
   questionCount: number;
   startedAt: string;
   locale: string;
+  messages: {
+    messageId: string;
+    type: "user" | "bot";
+    text: string;
+    createdAt: string;
+  }[];
 }
 
 export interface IHistoryStateContext {

--- a/frontend/src/providers/history-provider/index.tsx
+++ b/frontend/src/providers/history-provider/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useContext, useEffect, useEffectEvent, useReducer } from "react";
-import { getConversations } from "@/services/qaService";
+import { getConversation, getConversations } from "@/services/qaService";
 import { useAuth } from "@/hooks/useAuth";
 import { getUserFacingErrorMessage } from "@/lib/userFacingErrors";
 import { HistoryReducer } from "./reducer";
@@ -23,15 +23,38 @@ export const HistoryProvider = ({
     dispatch({ type: HistoryStateEnums.HISTORY_FETCH_ALL_PENDING });
     try {
       const result = await getConversations(user?.token);
+      const detailedItems = await Promise.all(
+        result.items.map(async (item) => {
+          try {
+            const conversation = await getConversation(
+              item.conversationId,
+              user?.token,
+            );
+
+            return {
+              conversationId: item.conversationId,
+              firstQuestion: item.firstQuestion,
+              questionCount: item.questionCount,
+              startedAt: item.startedAt,
+              locale: item.locale,
+              messages: conversation.messages,
+            };
+          } catch {
+            return {
+              conversationId: item.conversationId,
+              firstQuestion: item.firstQuestion,
+              questionCount: item.questionCount,
+              startedAt: item.startedAt,
+              locale: item.locale,
+              messages: [],
+            };
+          }
+        }),
+      );
+
       dispatch({
         type: HistoryStateEnums.HISTORY_FETCH_ALL_SUCCESS,
-        items: result.items.map((item) => ({
-          conversationId: item.conversationId,
-          firstQuestion: item.firstQuestion,
-          questionCount: item.questionCount,
-          startedAt: item.startedAt,
-          locale: item.locale,
-        })),
+        items: detailedItems,
         totalCount: result.totalCount,
       });
     } catch (error) {

--- a/frontend/src/services/contract.service.ts
+++ b/frontend/src/services/contract.service.ts
@@ -1,4 +1,5 @@
 import type {
+  ContractConversationMessage,
   ContractFlag,
   ContractFollowUpAnswer,
   ContractListItem,
@@ -189,7 +190,8 @@ export async function getContractAnalysis(
 export async function askContractQuestion(
   id: string,
   questionText: string,
-  locale?: string
+  locale?: string,
+  conversationHistory: ContractConversationMessage[] = []
 ): Promise<ContractFollowUpAnswer> {
   const response = await fetchWithFallback(`/api/app/contract/${id}/ask`, {
     method: "POST",
@@ -200,6 +202,7 @@ export async function askContractQuestion(
     body: JSON.stringify({
       questionText,
       responseLanguageCode: locale,
+      conversationHistory,
     }),
   });
 

--- a/frontend/src/services/qa.service.ts
+++ b/frontend/src/services/qa.service.ts
@@ -22,6 +22,7 @@ function getCookie(name: string): string | null {
 
 export interface AskQuestionRequest {
   questionText: string;
+  conversationId?: string;
 }
 
 export interface RagCitationDto {
@@ -48,6 +49,11 @@ export interface RagAnswerResult {
   answerText: string | null;
   isInsufficientInformation: boolean;
   detectedLanguageCode: string;
+  conversationId?: string | null;
+  primarySourceTitle?: string | null;
+  primarySourceLocator?: string | null;
+  primaryAuthorityType?: RagCitationAuthorityType | null;
+  hasSupportingSources?: boolean;
   answerMode: RagAnswerMode;
   confidenceBand: RagConfidenceBand;
   clarificationQuestion: string | null;
@@ -55,6 +61,23 @@ export interface RagAnswerResult {
   citations: RagCitationDto[];
   chunkIds: string[];
   answerId: string | null;
+}
+
+export interface ConversationHistoryMessage {
+  messageId: string;
+  type: "user" | "bot";
+  text: string;
+  createdAt: string;
+  detectedLanguageCode: string;
+  citations: RagCitationDto[];
+}
+
+export interface ConversationDetail {
+  conversationId: string;
+  startedAt: string;
+  language: string;
+  questionCount: number;
+  messages: ConversationHistoryMessage[];
 }
 
 const ANSWER_MODE_BY_NUMBER: Record<number, RagAnswerMode> = {
@@ -146,8 +169,10 @@ function normalizeCitation(citation: RagCitationDto): RagCitationDto {
     ...citation,
     sourceTitle: citation.sourceTitle ?? citation.actName,
     sourceLocator: citation.sourceLocator ?? citation.sectionNumber,
-    authorityType: normalizeAuthorityType(citation.authorityType),
-    sourceRole: normalizeSourceRole(citation.sourceRole),
+    authorityType: citation.authorityType
+      ? normalizeAuthorityType(citation.authorityType)
+      : null,
+    sourceRole: citation.sourceRole ? normalizeSourceRole(citation.sourceRole) : null,
   };
 }
 
@@ -156,6 +181,13 @@ function normalizeRagAnswerResult(result: RagAnswerResult): RagAnswerResult {
     ...result,
     answerMode: normalizeAnswerMode(result.answerMode),
     confidenceBand: normalizeConfidenceBand(result.confidenceBand),
+    conversationId: result.conversationId ?? null,
+    primarySourceTitle: result.primarySourceTitle ?? null,
+    primarySourceLocator: result.primarySourceLocator ?? null,
+    primaryAuthorityType: result.primaryAuthorityType
+      ? normalizeAuthorityType(result.primaryAuthorityType)
+      : null,
+    hasSupportingSources: Boolean(result.hasSupportingSources),
     requiresUrgentAttention: Boolean(result.requiresUrgentAttention),
     clarificationQuestion: result.clarificationQuestion ?? null,
     citations: Array.isArray(result.citations)
@@ -255,4 +287,64 @@ export async function askRagQuestion(
   }
   
   return normalizeRagAnswerResult(json as RagAnswerResult);
+}
+
+export async function getConversation(conversationId: string): Promise<ConversationDetail> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...ABP_TENANT_HEADER,
+  };
+
+  const token = getCookie("ml_token");
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  let lastNetworkError: TypeError | null = null;
+
+  for (const apiBase of getAskApiBaseCandidates()) {
+    try {
+      const res = await fetch(`${apiBase}/api/app/qa/conversations/${conversationId}`, {
+        method: "GET",
+        headers,
+      });
+
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({})) as {
+          error?: { message?: string };
+        };
+        throw new Error(json?.error?.message ?? `Request failed with status ${res.status}`);
+      }
+
+      const json = await res.json();
+      const result = (json.result ?? json) as ConversationDetail;
+
+      return {
+        conversationId: result.conversationId,
+        startedAt: result.startedAt,
+        language: result.language ?? "en",
+        questionCount: result.questionCount ?? 0,
+        messages: Array.isArray(result.messages)
+          ? result.messages.map((message) => ({
+              messageId: message.messageId,
+              type: message.type === "bot" ? "bot" : "user",
+              text: message.text ?? "",
+              createdAt: message.createdAt,
+              detectedLanguageCode: message.detectedLanguageCode ?? "en",
+              citations: Array.isArray(message.citations)
+                ? message.citations.map(normalizeCitation)
+                : [],
+            }))
+          : [],
+      };
+    } catch (error) {
+      if (!(error instanceof TypeError)) {
+        throw error;
+      }
+
+      lastNetworkError = error;
+    }
+  }
+
+  throw lastNetworkError ?? new TypeError("Failed to fetch");
 }

--- a/frontend/src/services/qaService.ts
+++ b/frontend/src/services/qaService.ts
@@ -133,6 +133,21 @@ export interface ConversationSummary {
   locale: string;
 }
 
+export interface ConversationHistoryMessage {
+  messageId: string;
+  type: "user" | "bot";
+  text: string;
+  createdAt: string;
+}
+
+export interface ConversationDetail {
+  conversationId: string;
+  startedAt: string;
+  language: string;
+  questionCount: number;
+  messages: ConversationHistoryMessage[];
+}
+
 export interface ConversationsListResponse {
   items: ConversationSummary[];
   totalCount: number;
@@ -168,6 +183,44 @@ export async function getConversations(token?: string): Promise<ConversationsLis
         }))
       : [],
     totalCount: result?.totalCount ?? 0,
+  };
+}
+
+export async function getConversation(
+  conversationId: string,
+  token?: string,
+): Promise<ConversationDetail> {
+  const authToken = token ?? getCookie("ml_token");
+  const res = await fetchWithFallback(`/api/app/qa/conversations/${conversationId}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      ...ABP_TENANT_HEADER,
+      ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+    },
+  });
+
+  const json = await res.json().catch(() => ({}));
+
+  if (!res.ok) {
+    throw new Error(json?.error?.message || "Failed to fetch conversation");
+  }
+
+  const result = (json.result ?? json) as ConversationDetail;
+
+  return {
+    conversationId: result.conversationId,
+    startedAt: result.startedAt,
+    language: result.language ?? "en",
+    questionCount: result.questionCount ?? 0,
+    messages: Array.isArray(result.messages)
+      ? result.messages.map((message) => ({
+          messageId: message.messageId,
+          type: message.type === "bot" ? "bot" : "user",
+          text: message.text ?? "",
+          createdAt: message.createdAt,
+        }))
+      : [],
   };
 }
 

--- a/specs/feat-025-refine-rag-system/checklists/requirements.md
+++ b/specs/feat-025-refine-rag-system/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Authority-Aware RAG Refinement
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-02  
+**Feature**: [spec.md](C:/Users/Nhlakanipho/Documents/Projects/Mzansi-legal/specs/feat-025-refine-rag-system/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The spec is ready for `/speckit.plan`.

--- a/specs/feat-025-refine-rag-system/spec.md
+++ b/specs/feat-025-refine-rag-system/spec.md
@@ -1,0 +1,129 @@
+# Feature Specification: Authority-Aware RAG Refinement
+
+**Feature Branch**: `feat/025-refine-rag-system`  
+**Created**: 2026-04-02  
+**Status**: Draft  
+**Input**: User description: "Refine the MzansiLegal RAG system to improve grounded legal answer quality, authority handling, multilingual reliability, corpus freshness, and fallback behavior based on the current architecture and constraints."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Receive a grounded answer from the right legal authority (Priority: P1)
+
+A person asks a legal or financial question and receives an answer that is grounded in the most relevant South African source material. The answer makes it clear which sources are binding law, which are only supporting guidance, and which source is controlling when more than one source is cited.
+
+**Why this priority**: The product promise depends on users being able to trust that answers come from the right legal authority, not just from text that happens to look similar.
+
+**Independent Test**: Ask benchmark questions across employment, housing, consumer, privacy, debt, tax, and insurance topics and confirm the answer cites the correct primary source or source set with the controlling authority clearly identified.
+
+**Acceptance Scenarios**:
+
+1. **Given** a question is directly answered by a binding law source, **When** the system returns a response, **Then** the answer cites that binding source as the primary authority.
+2. **Given** a question requires both binding law and procedural guidance, **When** the system answers, **Then** the response clearly distinguishes which source controls the legal rule and which source only supports next steps or process.
+3. **Given** retrieved material includes a source with similar wording but lower legal relevance, **When** the answer is generated, **Then** that source does not displace the more directly relevant governing source.
+
+---
+
+### User Story 2 - Get a safe answer when support is weak, conflicting, or incomplete (Priority: P2)
+
+A user asks a broad, ambiguous, urgent, or weakly supported question. Instead of sounding falsely certain, the system becomes more cautious, asks for clarification when needed, highlights when authority is missing or mixed, and escalates appropriately for high-risk situations.
+
+**Why this priority**: A legal assistant must fail safely. Trust is damaged faster by overconfident wrong answers than by careful, limited answers.
+
+**Independent Test**: Submit ambiguous, unsupported, conflicting, and urgent test questions and verify the response changes posture appropriately instead of always returning a direct answer.
+
+**Acceptance Scenarios**:
+
+1. **Given** the retrieved support is too weak to answer responsibly, **When** the system responds, **Then** it states that support is insufficient and avoids a definitive conclusion.
+2. **Given** a question could be answered accurately if one missing fact were provided, **When** the system responds, **Then** it asks a clarifying follow-up instead of guessing.
+3. **Given** a question describes an urgent or high-risk situation, **When** the available support is limited or context-dependent, **Then** the system includes a clear escalation cue toward official or legal help.
+
+---
+
+### User Story 3 - Ask in a supported language without losing legal meaning (Priority: P3)
+
+A person asks a question in English, isiZulu, Sesotho, or Afrikaans. The system still identifies the correct legal meaning, finds the same governing authority as the English equivalent, and responds in the user’s language while keeping legal source labels verifiable.
+
+**Why this priority**: Multilingual access is core to the product. Retrieval quality must not materially drop for users who do not ask in English.
+
+**Independent Test**: Ask equivalent benchmark questions in each supported language and compare the returned primary source set, answer posture, and citation clarity against the English baseline.
+
+**Acceptance Scenarios**:
+
+1. **Given** two questions in different supported languages express the same legal issue, **When** both are answered, **Then** they cite the same primary governing source or materially equivalent source set.
+2. **Given** a non-English answer is returned, **When** the user reads the response, **Then** the legal explanation is in the requested language while Act names and source locators remain clear and consistent.
+3. **Given** a translation loses important legal nuance, **When** the system detects that confidence has dropped, **Then** it shifts to a more cautious answer posture rather than presenting a confident conclusion.
+
+---
+
+### User Story 4 - Keep the legal corpus trustworthy as sources change (Priority: P4)
+
+A product operator updates or refreshes public legal and regulatory source material. The question-answering system uses the refreshed source set, avoids citing superseded material once the update is complete, and preserves traceability about where each answer came from.
+
+**Why this priority**: Even a strong retrieval system becomes unsafe if it answers from stale or untraceable source material.
+
+**Independent Test**: Refresh a source that changes legal wording or guidance, then verify that subsequent answers cite the updated source while outdated material is no longer presented as current.
+
+**Acceptance Scenarios**:
+
+1. **Given** a public legal or regulatory source has been refreshed, **When** the refresh is completed, **Then** subsequent answers use the refreshed source rather than the superseded version.
+2. **Given** a source is not approved for use because its provenance or usage rights are unclear, **When** the system selects supporting material, **Then** that source is excluded from user-facing answers.
+3. **Given** a user reviews an answer after a source refresh, **When** they inspect the citations, **Then** each citation can still be traced back to a specific source passage and locator.
+
+---
+
+### Edge Cases
+
+- What happens when binding law and official guidance appear to point in different directions for the same user question?
+- How does the system behave when no retrieved source is authoritative enough to support a direct legal conclusion?
+- What happens when a translated question and its English equivalent retrieve different sources with similar confidence?
+- How does the system respond when an urgent scenario is described but the available authority only covers part of the issue?
+- What happens when a source refresh changes the controlling section after earlier answers were already stored?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST prioritize sources that directly govern the user’s issue over sources that merely share overlapping terms.
+- **FR-002**: The system MUST distinguish between binding law and supporting official guidance in every answer that uses both.
+- **FR-003**: The system MUST identify which cited source is controlling when more than one source is presented.
+- **FR-004**: The system MUST NOT present guidance-only support as though it were binding law.
+- **FR-005**: When authoritative support is weak, incomplete, or absent, the system MUST shift to a limited response posture rather than giving a definitive legal conclusion.
+- **FR-006**: When one additional fact would materially change the answer, the system MUST ask a targeted clarification question instead of guessing.
+- **FR-007**: When a query indicates urgency or high risk, the system MUST include an appropriate escalation cue if a direct grounded conclusion cannot be given safely.
+- **FR-008**: Semantically equivalent questions in the supported languages MUST lead to materially consistent governing-source selection and answer posture.
+- **FR-009**: The system MUST answer in the user’s requested or detected language while preserving clear source names and locators for verification.
+- **FR-010**: The system MUST expose the role of each citation in the response so users can tell whether a source is primary or supplementary.
+- **FR-011**: The system MUST preserve traceability from each answer back to the specific supporting source passage used to justify it.
+- **FR-012**: Refreshed or replaced source material MUST become the active basis for future answers once the refresh is approved and completed.
+- **FR-013**: Sources without acceptable provenance, freshness status, or usage rights MUST be excluded from user-facing retrieval and answers.
+- **FR-014**: Previously stored answers and citations MUST remain auditable after corpus refinement, including when source content has since been refreshed or superseded.
+- **FR-015**: The refinement MUST preserve POPIA-compatible handling for stored user interactions and MUST NOT broaden exposure of personal information in answer review or citation surfaces.
+
+### Key Entities *(include if feature involves data)*
+
+- **User Question**: A legal or financial question asked in one of the supported languages, including wording, context, and urgency signals.
+- **Retrieved Source**: A candidate law, regulation, guide, or official material selected to support an answer, including its authority role and freshness status.
+- **Authority Role**: The classification that explains whether a source is binding, supplementary, procedural, or unsuitable for a controlling legal conclusion.
+- **Answer Posture**: The response mode chosen for a question, such as direct answer, cautious answer, clarification request, or insufficient-support response.
+- **Source Refresh Record**: The metadata that indicates a source’s provenance, approval state, freshness, and whether it supersedes an earlier version.
+- **Citation Trace**: The user-visible and auditable record linking an answer claim to the exact supporting source passage and locator.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On a benchmark set of supported legal and financial questions, at least 90% of answers cite the correct primary governing source or source set.
+- **SC-002**: 100% of answers that rely only on supplementary guidance or weak support clearly disclose that limitation and avoid presenting a definitive legal conclusion.
+- **SC-003**: On benchmark questions translated across the supported languages, at least 90% of non-English variants return the same primary governing source or materially equivalent source set as the English baseline.
+- **SC-004**: 100% of urgent or high-risk test scenarios either provide a safely grounded answer or include a clear clarification or escalation cue when support is not strong enough.
+- **SC-005**: After an approved source refresh, new answers stop citing the superseded source in the affected topic area within one completed refresh cycle.
+- **SC-006**: 100% of user-facing answer claims remain traceable to a stored citation record with a source role and locator that a reviewer can audit.
+
+## Assumptions
+
+- The existing ask flow, history flow, persistence model, and current supported languages remain in place; this feature refines answer quality rather than replacing those journeys.
+- The current public South African legal and regulatory corpus remains the baseline source set for this refinement.
+- Only sources with acceptable public availability and usage rights are eligible for inclusion in grounded answers.
+- The product continues to provide legal information, not legal representation or formal legal advice.
+- Corpus refreshes may continue to be triggered through existing operational workflows; this feature focuses on trust, source selection, and answer behavior rather than introducing a new operator interface from scratch.
+- Existing personal-information handling for stored questions and answers remains the compliance baseline and is not reduced by this feature.


### PR DESCRIPTION
This pull request introduces support for preserving and utilizing conversation history in contract follow-up Q&A, enhancing the system's ability to handle follow-up questions with context. It also adds new DTOs and API endpoints to expose and consume conversation threads, updates prompt construction to include recent conversation messages, and expands the answer result structure with more metadata about legal sources.

Key changes include:

**Conversation History Support:**

* Added a new `ContractConversationHistoryMessageDto` DTO and updated `AskContractQuestionRequest` to include a `ConversationHistory` property, allowing clients to send prior messages for context in follow-up questions. [[1]](diffhunk://#diff-609f866719c090b31cb3a615f163d45d051af5426c19dbcbf6afcd5f254565ecR1-R11) [[2]](diffhunk://#diff-e32d02d956501e8371af20aa04739d2d2b1b1a94c874501cbba3c6157d4322fdR13-R14)
* Updated the `ContractFollowUpService.AskAsync` method and its call chain to accept and process conversation history, using it to build context-aware prompts for retrieval and answer generation. [[1]](diffhunk://#diff-eebc3d0919388c3e2489ed83aa834737319f8eb330d990ae4cb3d215112db5f1L129-R130) [[2]](diffhunk://#diff-bac477e935c463fb5411dadcfabeae4adc6205f2f7996b47e499b2b7c861cecaL79-R82) [[3]](diffhunk://#diff-bac477e935c463fb5411dadcfabeae4adc6205f2f7996b47e499b2b7c861cecaL90-R100) [[4]](diffhunk://#diff-bac477e935c463fb5411dadcfabeae4adc6205f2f7996b47e499b2b7c861cecaL115-R120) [[5]](diffhunk://#diff-bac477e935c463fb5411dadcfabeae4adc6205f2f7996b47e499b2b7c861cecaL203-R209) [[6]](diffhunk://#diff-bac477e935c463fb5411dadcfabeae4adc6205f2f7996b47e499b2b7c861cecaL212-R219) [[7]](diffhunk://#diff-bac477e935c463fb5411dadcfabeae4adc6205f2f7996b47e499b2b7c861cecaL348-R366) [[8]](diffhunk://#diff-bac477e935c463fb5411dadcfabeae4adc6205f2f7996b47e499b2b7c861cecaR381-R431)
* Limited the number of conversation history messages included in prompts to the most recent six, and formatted them for clarity. [[1]](diffhunk://#diff-bac477e935c463fb5411dadcfabeae4adc6205f2f7996b47e499b2b7c861cecaR26-R27) [[2]](diffhunk://#diff-bac477e935c463fb5411dadcfabeae4adc6205f2f7996b47e499b2b7c861cecaR381-R431)

**Prompt and Answer Generation Enhancements:**

* Modified system and user prompts to incorporate conversation history, clarify its role (context only, not legal authority), and updated instructions to the model regarding follow-up references. [[1]](diffhunk://#diff-bac477e935c463fb5411dadcfabeae4adc6205f2f7996b47e499b2b7c861cecaL314-R331) [[2]](diffhunk://#diff-bac477e935c463fb5411dadcfabeae4adc6205f2f7996b47e499b2b7c861cecaL336-R344) [[3]](diffhunk://#diff-bac477e935c463fb5411dadcfabeae4adc6205f2f7996b47e499b2b7c861cecaL348-R366)
* Improved logic for determining relevant contract excerpts and context by using the combined question and conversation history.

**Conversation Thread API and DTOs:**

* Introduced `ConversationDetailDto` and `ConversationHistoryMessageDto` to represent full stored conversation threads and their messages. [[1]](diffhunk://#diff-21f5b8974deac527898ecd03462d56f1a96f00793cd507227017cbf6f8b35b32R1-R20) [[2]](diffhunk://#diff-fd197d32914f981bfa37453a4c82019d1daacfa2f055d5f65aee9dfc300eefdeR1-R22)
* Added a new `GetConversationAsync` API endpoint in `IRagAppService` and its implementation in `RagAppService` to retrieve full conversation threads for authenticated users. [[1]](diffhunk://#diff-2afdc3c4dcb3fb2c23c3d876c001f94c5942cb4fcdcda446b5988ab56083f1cfR39-R43) [[2]](diffhunk://#diff-9dd0279578e93fc0bb3f440d6bf808ad076919b3287d300454c7e897750b5f78R162-R175)

**Answer Result Metadata Expansion:**

* Extended `RagAnswerResult` to include metadata about the primary legal source used in the answer, such as title, locator, authority type, and whether there are supporting sources.

**General Improvements:**

* Improved comments and documentation throughout the codebase for clarity, especially regarding the handling and usage of conversation history and answer metadata. [[1]](diffhunk://#diff-c4070e598b62e472c781b0fdf4b10be38afa8e3bc3f9cb53d340afbe08d571b4L41-R47) [[2]](diffhunk://#diff-9dd0279578e93fc0bb3f440d6bf808ad076919b3287d300454c7e897750b5f78L26-R32)

These changes collectively make the contract Q&A system more robust for multi-turn conversations, improve answer traceability, and provide richer API support for clients.

issue #73 #11 